### PR TITLE
react: send unicode glyphs on the wire instead of shortcodes

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/ReactionPalette.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/ReactionPalette.kt
@@ -1,9 +1,12 @@
 package io.nisfeb.talon.ui
 
 /**
- * Minimal v1 reaction palette. Tlon's wire format is a shortcode like
- * ":+1:" or a URL-escaped form like "%2B1" — we send and store the
- * shortcode and map to a display character only at render time.
+ * Minimal v1 reaction palette. Tlon migrated reactions from shortcodes
+ * to unicode glyphs in 2025, so the wire format is now a unicode
+ * string like "👍". TlonChatRepo.react() normalizes shortcodes to
+ * glyphs before sending and before the optimistic local upsert; the
+ * picker map below is also used as a fallback display() table for any
+ * legacy shortcode rows that remain in the local DB.
  */
 object ReactionPalette {
 

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmChatScreen.kt
@@ -568,7 +568,12 @@ fun DmChatScreen(
     val onReactionForMessage: (MessageEntity, List<ReactionEntity>, String) -> Unit =
         remember(ourPatp) {
             { m, reactions, emoji ->
-                val mineSame = reactions.any { it.author == ourPatp && it.emoji == emoji }
+                // Compare on glyph: outbound reactions are normalized to
+                // unicode in TlonChatRepo.react(), so the DB row for our
+                // own reaction is a glyph even when the picker hands us
+                // a shortcode.
+                val ours = ReactionPalette.display(emoji)
+                val mineSame = reactions.any { it.author == ourPatp && it.emoji == ours }
                 scope.launch {
                     runCatching {
                         if (mineSame) repo.unreact(m.whom, m.id)

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/ThreadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/ThreadScreen.kt
@@ -227,7 +227,12 @@ fun ThreadScreen(
     val onReactionForMessage: (MessageEntity, List<ReactionEntity>, String) -> Unit =
         remember(ourPatp, whom, repo) {
             { m, rs, emoji ->
-                val mineSame = rs.any { it.author == ourPatp && it.emoji == emoji }
+                // Compare on glyph: outbound reactions are normalized to
+                // unicode in TlonChatRepo.react(), so the DB row for our
+                // own reaction is a glyph even when the picker hands us
+                // a shortcode.
+                val ours = ReactionPalette.display(emoji)
+                val mineSame = rs.any { it.author == ourPatp && it.emoji == ours }
                 scope.launch {
                     runCatching {
                         if (mineSame) repo.unreact(whom, m.id)

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
@@ -33,6 +33,7 @@ import io.nisfeb.talon.data.GroupEntity
 import io.nisfeb.talon.data.MessageEntity
 import io.nisfeb.talon.data.ReactionEntity
 import io.nisfeb.talon.data.UnreadEntity
+import io.nisfeb.talon.ui.ReactionPalette
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -1779,13 +1780,23 @@ class TlonChatRepo(
         return StorageConfig(bucket, region, publicUrlBase, service)
     }
 
-    /** Add or replace our reaction on a post. `emoji` is a raw shortcode. */
+    /**
+     * Add or replace our reaction on a post. The caller may pass either
+     * a shortcode (`:+1:`) or a unicode glyph (`👍`); we normalize to a
+     * glyph here because Tlon migrated reactions away from shortcodes
+     * to unicode in 2025 — every other Tlon client now sends glyphs on
+     * the wire, so emitting a shortcode would fragment reaction
+     * grouping (a `:+1:` from us and a `👍` from web Tlon become two
+     * separate chips). `ReactionPalette.display` is shortcode→glyph
+     * with a passthrough fallback, so glyphs in stay glyphs out.
+     */
     suspend fun react(whom: String, postId: String, emoji: String) {
         val ch = channel ?: error("not connected")
+        val glyph = ReactionPalette.display(emoji)
         val delta = buildJsonObject {
             put("add-react", buildJsonObject {
                 put("author", ourPatp)
-                put("react", emoji)
+                put("react", glyph)
             })
         }
         when {
@@ -1812,15 +1823,15 @@ class TlonChatRepo(
                             // local optimistic upsert sticks, and
                             // other devices never see the vote).
                             put("ship", ourPatp)
-                            put("react", emoji)
+                            put("react", glyph)
                         })
                     })
                 }),
             )
             else -> error("unsupported whom: $whom")
         }
-        db.reactions().upsert(ReactionEntity(whom, postId, ourPatp, emoji))
-        runCatching { db.reactionUsage().bump(emoji) }
+        db.reactions().upsert(ReactionEntity(whom, postId, ourPatp, glyph))
+        runCatching { db.reactionUsage().bump(glyph) }
     }
 
     /** Remove our reaction from a post. */


### PR DESCRIPTION
## Summary

- `TlonChatRepo.react()` now sends a unicode glyph (e.g. `👍`) in `add-react` pokes instead of a shortcode (`:+1:`). The local optimistic upsert and `reactionUsage` bump use the same normalized glyph.
- `mineSame` comparisons in `DmChatScreen` and `ThreadScreen` are normalized through `ReactionPalette.display()` so a re-tap on our own reaction still toggles off.
- `ReactionPalette` header comment updated to reflect the current wire format. Its picker map continues to serve as a display fallback for any legacy shortcode rows in the local DB.

## Why

Tlon migrated reactions away from shortcodes to unicode glyphs in 2025; web, iOS, and Android Tlon clients now send glyphs on the wire. Talon was still emitting shortcodes, so a Talon `:+1:` and a web Tlon `👍` rendered as two separate reaction chips on every client. This patch aligns Talon with the rest of the ecosystem.

The conversion happens at the wire boundary (one place — `react()`), so call sites (`DmChatScreen`, `ThreadScreen`, AI suggestions in `AiFeatures`) can keep handing in either form. `ReactionPalette.display()` is shortcode→glyph with a passthrough fallback, so glyphs in stay glyphs out.

## Notes

- Local DB rows for past Talon reactions remain shortcodes; they continue to render via `ReactionPalette.display()`'s shortcode→glyph fallback. No migration is performed.
- The `del-react` path is unchanged — it doesn't carry an emoji.
- Out of scope: thread-reply reaction routing (`react()` doesn't take a `parentId`, so reactions on replies still go through the top-level path; that's a pre-existing concern unrelated to wire format).

## Test plan

- [x] `./gradlew :composeApp:compileKotlinDesktop` — clean
- [x] `./gradlew :composeApp:desktopTest` — all pass
- [ ] Manual: tap a reaction in a DM, club, and channel post; verify it appears on a separate Tlon web client as the same glyph chip (not a separate `:+1:` chip)
- [ ] Manual: re-tap the same reaction to confirm it toggles off (mineSame works post-server-echo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)