### PR TITLE
feat(urb): recognize urb:// links and hand off to Lattice

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Android 11+ package visibility: without this, queryIntentActivities
+         for the urb:// scheme is filtered to empty even when Lattice is
+         installed, so AndroidUrbLinkLauncher would always report
+         NotInstalled. Declares that we need to see urb:// VIEW handlers. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="urb" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/composeApp/src/androidMain/kotlin/io/nisfeb/talon/ui/TalonApp.kt
+++ b/composeApp/src/androidMain/kotlin/io/nisfeb/talon/ui/TalonApp.kt
@@ -601,6 +601,21 @@ fun TalonApp(
             runCatching { context.startActivity(intent) }
         }
     }
+    // urb:// link handoff to Lattice — resolve + open off the main
+    // thread, raise the install prompt when no handler is present.
+    var urbPromptUrl by remember { mutableStateOf<String?>(null) }
+    val urbScope = rememberCoroutineScope()
+    val urbLauncher = remember(app) { io.nisfeb.talon.urbit.AndroidUrbLinkLauncher(app) }
+    val urbLinkHandler: (String) -> Unit = remember(urbLauncher) {
+        { url ->
+            urbScope.launch {
+                val r = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                    urbLauncher.open(url)
+                }
+                if (r != io.nisfeb.talon.urbit.UrbLaunchResult.Opened) urbPromptUrl = url
+            }
+        }
+    }
     androidx.compose.runtime.CompositionLocalProvider(
         // Bind the real ExoPlayer-backed inline players for chat
         // messages. Without this, StoryRenderer falls back to a
@@ -613,7 +628,11 @@ fun TalonApp(
         },
         LocalCalendarLauncher provides calendarLauncher,
         LocalMapsLauncher provides mapsLauncher,
+        io.nisfeb.talon.ui.LocalUrbLinkHandler provides urbLinkHandler,
     ) {
+    urbPromptUrl?.let {
+        io.nisfeb.talon.ui.InstallLatticeDialog(onDismiss = { urbPromptUrl = null })
+    }
     Scaffold(contentWindowInsets = WindowInsets(0, 0, 0, 0)) { _ ->
         val mod = Modifier.fillMaxSize()
 

--- a/composeApp/src/androidMain/kotlin/io/nisfeb/talon/urbit/AndroidUrbLinkLauncher.kt
+++ b/composeApp/src/androidMain/kotlin/io/nisfeb/talon/urbit/AndroidUrbLinkLauncher.kt
@@ -1,0 +1,39 @@
+package io.nisfeb.talon.urbit
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import io.nisfeb.talon.util.Log
+
+/**
+ * Android [UrbLinkLauncher]. Fires an `ACTION_VIEW` intent for the
+ * urb:// URI; Lattice (or any app that registers the scheme) catches
+ * it. Resolves installed-or-not via the package manager so a tap on a
+ * link with no handler surfaces the install prompt instead of an
+ * ActivityNotFoundException.
+ */
+class AndroidUrbLinkLauncher(context: Context) : UrbLinkLauncher {
+    // Application context — the launcher outlives any one Activity.
+    private val appContext = context.applicationContext
+
+    override fun open(url: String): UrbLaunchResult {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+            // We're launching from outside an Activity context (the
+            // launcher is held at application scope), so a new task is
+            // required or startActivity throws.
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        // queryIntentActivities is the reliable "is there a handler?"
+        // check — resolveActivity can return the system resolver even
+        // when nothing concrete handles the scheme.
+        val handlers = appContext.packageManager.queryIntentActivities(intent, 0)
+        if (handlers.isEmpty()) return UrbLaunchResult.NotInstalled
+        return try {
+            appContext.startActivity(intent)
+            UrbLaunchResult.Opened
+        } catch (e: Exception) {
+            Log.w("UrbLinkLauncher", "startActivity failed for $url: ${e.message}")
+            UrbLaunchResult.Failed
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
@@ -178,6 +178,12 @@ fun App(
      *  conversation instead of an empty pane. Default Noop for tests. */
     lastOpenChatStore: io.nisfeb.talon.notify.LastOpenChatStore =
         io.nisfeb.talon.notify.NoopLastOpenChatStore,
+    /** Opens urb:// links (Lattice handoff). Desktop passes
+     *  DesktopUrbLinkLauncher, Android AndroidUrbLinkLauncher; the
+     *  Noop default reports NotInstalled so tests / unwired hosts
+     *  show the install prompt rather than swallowing taps. */
+    urbLinkLauncher: io.nisfeb.talon.urbit.UrbLinkLauncher =
+        io.nisfeb.talon.urbit.NoopUrbLinkLauncher,
 ) {
     // Derive the initial logged-in ship from sessionStore.active()
     // (the joined SavedSession) rather than activeShip() (just the
@@ -691,11 +697,30 @@ fun App(
                   fontScale = baseDensity.fontScale * chatDensity.fontScaleMultiplier,
               )
           }
+          // urb:// link handoff to Lattice. The handler resolves the
+          // scheme off-thread (desktop shells to xdg-mime/xdg-open) and
+          // raises the install prompt when no handler is present.
+          var urbPromptUrl by remember { mutableStateOf<String?>(null) }
+          val urbScope = rememberCoroutineScope()
+          val urbLinkHandler: (String) -> Unit = remember(urbLinkLauncher) {
+              { url ->
+                  urbScope.launch {
+                      val r = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                          urbLinkLauncher.open(url)
+                      }
+                      if (r != io.nisfeb.talon.urbit.UrbLaunchResult.Opened) urbPromptUrl = url
+                  }
+              }
+          }
           androidx.compose.runtime.CompositionLocalProvider(
               io.nisfeb.talon.ui.LocalImageDownloader provides imageDownloader,
               io.nisfeb.talon.ui.LocalChatDensity provides chatDensity,
               androidx.compose.ui.platform.LocalDensity provides scaledDensity,
+              io.nisfeb.talon.ui.LocalUrbLinkHandler provides urbLinkHandler,
           ) {
+            urbPromptUrl?.let {
+                io.nisfeb.talon.ui.InstallLatticeDialog(onDismiss = { urbPromptUrl = null })
+            }
             val rootFocusRequester = remember { FocusRequester() }
             LaunchedEffect(Unit) { rootFocusRequester.requestFocus() }
             Surface(

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/UrbLinkHandling.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/UrbLinkHandling.kt
@@ -1,0 +1,88 @@
+package io.nisfeb.talon.ui
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalUriHandler
+import io.nisfeb.talon.urbit.UrbLaunchResult
+import io.nisfeb.talon.urbit.UrbLinkLauncher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Carries the "open this urb:// link" action down to chat renderers
+ * without threading a parameter through every screen — mirrors the
+ * [androidx.compose.ui.platform.LocalUriHandler] pattern. The chat
+ * screens' `onLinkTap` branches on the urb:// prefix and dispatches
+ * here; everything else still goes through the normal URI handler.
+ *
+ * Default is a no-op so previews / tests that don't wrap content in
+ * [ProvideUrbLinkHandler] don't crash on a tap.
+ */
+val LocalUrbLinkHandler = staticCompositionLocalOf<(String) -> Unit> { {} }
+
+/**
+ * Wraps [content] with a urb:// handler backed by [launcher], and
+ * hosts the "install Lattice" prompt that appears when no urb://
+ * handler is present on the device.
+ *
+ * The launch runs off the main thread — the desktop launcher shells
+ * out to `xdg-mime` / `xdg-open`, which would otherwise block the UI
+ * thread on the process round-trip.
+ */
+@Composable
+fun ProvideUrbLinkHandler(
+    launcher: UrbLinkLauncher,
+    content: @Composable () -> Unit,
+) {
+    var promptUrl by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+    val handler: (String) -> Unit = remember(launcher) {
+        { url ->
+            scope.launch {
+                val result = withContext(Dispatchers.IO) { launcher.open(url) }
+                if (result != UrbLaunchResult.Opened) promptUrl = url
+            }
+        }
+    }
+    CompositionLocalProvider(LocalUrbLinkHandler provides handler) {
+        content()
+    }
+    promptUrl?.let { url ->
+        InstallLatticeDialog(onDismiss = { promptUrl = null })
+    }
+}
+
+@Composable
+fun InstallLatticeDialog(onDismiss: () -> Unit) {
+    val uriHandler = LocalUriHandler.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Opens in Lattice") },
+        text = {
+            Text(
+                "This is a urb:// link — an address on the Urbit network. " +
+                    "Lattice, a peer-to-peer gemtext browser, opens these. " +
+                    "Install it to follow the link.",
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onDismiss()
+                runCatching { uriHandler.openUri(UrbLinkLauncher.INSTALL_URL) }
+            }) { Text("Install Lattice") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Not now") }
+        },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/UrbLinkHandling.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/UrbLinkHandling.kt
@@ -4,19 +4,9 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalUriHandler
-import io.nisfeb.talon.urbit.UrbLaunchResult
 import io.nisfeb.talon.urbit.UrbLinkLauncher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * Carries the "open this urb:// link" action down to chat renderers
@@ -25,43 +15,16 @@ import kotlinx.coroutines.withContext
  * screens' `onLinkTap` branches on the urb:// prefix and dispatches
  * here; everything else still goes through the normal URI handler.
  *
- * Default is a no-op so previews / tests that don't wrap content in
- * [ProvideUrbLinkHandler] don't crash on a tap.
+ * Provided at the app root (App.kt on desktop, TalonApp.kt on Android)
+ * wired to the platform [UrbLinkLauncher]. Default is a no-op so
+ * previews / tests / surfaces that don't provide it don't crash on a tap.
  */
 val LocalUrbLinkHandler = staticCompositionLocalOf<(String) -> Unit> { {} }
 
 /**
- * Wraps [content] with a urb:// handler backed by [launcher], and
- * hosts the "install Lattice" prompt that appears when no urb://
- * handler is present on the device.
- *
- * The launch runs off the main thread — the desktop launcher shells
- * out to `xdg-mime` / `xdg-open`, which would otherwise block the UI
- * thread on the process round-trip.
+ * Prompt shown when a tapped urb:// link has no handler on the device.
+ * Links to Lattice's releases via the platform URI handler.
  */
-@Composable
-fun ProvideUrbLinkHandler(
-    launcher: UrbLinkLauncher,
-    content: @Composable () -> Unit,
-) {
-    var promptUrl by remember { mutableStateOf<String?>(null) }
-    val scope = rememberCoroutineScope()
-    val handler: (String) -> Unit = remember(launcher) {
-        { url ->
-            scope.launch {
-                val result = withContext(Dispatchers.IO) { launcher.open(url) }
-                if (result != UrbLaunchResult.Opened) promptUrl = url
-            }
-        }
-    }
-    CompositionLocalProvider(LocalUrbLinkHandler provides handler) {
-        content()
-    }
-    promptUrl?.let { url ->
-        InstallLatticeDialog(onDismiss = { promptUrl = null })
-    }
-}
-
 @Composable
 fun InstallLatticeDialog(onDismiss: () -> Unit) {
     val uriHandler = LocalUriHandler.current

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmChatScreen.kt
@@ -535,8 +535,12 @@ fun DmChatScreen(
         { patp -> profileSheetShip = patp }
     }
     val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
-    val onLinkTap: (String) -> Unit = remember(uriHandler) {
-        { url -> runCatching { uriHandler.openUri(url) } }
+    val urbLinkHandler = io.nisfeb.talon.ui.LocalUrbLinkHandler.current
+    val onLinkTap: (String) -> Unit = remember(uriHandler, urbLinkHandler) {
+        { url ->
+            if (io.nisfeb.talon.urbit.UrbLink.isUrbUrl(url)) urbLinkHandler(url)
+            else runCatching { uriHandler.openUri(url) }
+        }
     }
     val onCitationTap: (String) -> Unit = remember {
         { target -> currentOnOpenConversation(target) }

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/ThreadList.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/ThreadList.kt
@@ -284,8 +284,12 @@ fun ThreadList(
         { patp -> onOpenConversation(patp) }
     }
     val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
-    val onLinkTap: (String) -> Unit = remember(uriHandler) {
-        { url -> runCatching { uriHandler.openUri(url) } }
+    val urbLinkHandler = io.nisfeb.talon.ui.LocalUrbLinkHandler.current
+    val onLinkTap: (String) -> Unit = remember(uriHandler, urbLinkHandler) {
+        { url ->
+            if (io.nisfeb.talon.urbit.UrbLink.isUrbUrl(url)) urbLinkHandler(url)
+            else runCatching { uriHandler.openUri(url) }
+        }
     }
     val onImageTap: (String) -> Unit = remember(onOpenImage) {
         { url -> onOpenImage(url) }

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/Story.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/Story.kt
@@ -233,9 +233,37 @@ object Story {
 
     // ───────── inline spans ─────────
 
+    /**
+     * Append [text] to [out], but linkify any bare `urb://` runs:
+     * Tlon's server-side linkifier only wraps http(s) URLs in `link`
+     * blocks, so urb:// addresses arrive as plain text. We annotate
+     * those runs with [URL_TAG] (the same tag http links use) so the
+     * renderer makes them tappable — the tap site branches on the
+     * urb:// prefix to route through Lattice instead of the browser.
+     */
+    private fun appendLinkifyingUrb(text: String, out: androidx.compose.ui.text.AnnotatedString.Builder) {
+        val ranges = UrbLink.findRanges(text)
+        if (ranges.isEmpty()) {
+            out.append(text)
+            return
+        }
+        var cursor = 0
+        for (r in ranges) {
+            if (r.first > cursor) out.append(text.substring(cursor, r.first))
+            val url = text.substring(r.first, r.last + 1)
+            out.pushStringAnnotation(URL_TAG, url)
+            out.withSpan(SpanStyle(color = LINK_COLOR, textDecoration = TextDecoration.Underline)) {
+                append(url)
+            }
+            out.pop()
+            cursor = r.last + 1
+        }
+        if (cursor < text.length) out.append(text.substring(cursor))
+    }
+
     private fun renderInline(element: JsonElement, out: androidx.compose.ui.text.AnnotatedString.Builder) {
         (element as? JsonPrimitive)?.let {
-            out.append(if (it.isString) it.content else it.content)
+            appendLinkifyingUrb(if (it.isString) it.content else it.content, out)
             return
         }
         val obj = element as? JsonObject ?: return

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/UrbLink.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/UrbLink.kt
@@ -1,0 +1,66 @@
+package io.nisfeb.talon.urbit
+
+/**
+ * Detection of `urb://~ship/path` links in free message text.
+ *
+ * `urb://` is the address scheme used by Lattice (a peer-to-peer
+ * gemtext browser for Urbit). Tlon's server-side linkifier only wraps
+ * http(s) URLs into `link` blocks, so a `urb://` address typed into a
+ * chat arrives as plain text — this object finds those runs so the
+ * renderer can make them tappable and hand them off to Lattice.
+ *
+ * We deliberately don't validate the ship phonemes (Lattice's own
+ * `UrbUrl.parse` is tolerant too); the `urb://` scheme prefix plus a
+ * non-empty remainder is signal enough to linkify. Matching mirrors
+ * Lattice's `UrbUrl.isUrb` (`startsWith("urb://")`).
+ */
+object UrbLink {
+    const val SCHEME = "urb://"
+
+    // urb:// followed by one-or-more non-whitespace, non-delimiter
+    // chars. Excludes the handful of characters that commonly sit
+    // *after* a URL in prose (quotes, angle brackets) so we don't
+    // swallow them into the link.
+    private val URB_RE = Regex("""urb://[^\s<>"'`]+""")
+
+    // Trailing characters trimmed off a matched run — sentence
+    // punctuation that almost never belongs to the URL itself. A
+    // closing paren is trimmed only when the run has no opening paren
+    // (so `urb://~ship/a(b)` keeps its balanced pair).
+    private const val TRAILING_TRIM = ".,;:!?"
+
+    /** True when [s] is exactly a urb:// URL (no surrounding text). */
+    fun isUrbUrl(s: String): Boolean {
+        val t = s.trim()
+        if (!t.startsWith(SCHEME)) return false
+        if (t.length <= SCHEME.length) return false
+        return t.none { it.isWhitespace() }
+    }
+
+    /**
+     * Find every urb:// run in [text]. Returns ranges (inclusive) into
+     * the original string, left-to-right, non-overlapping. Trailing
+     * sentence punctuation is excluded from each range.
+     */
+    fun findRanges(text: String): List<IntRange> {
+        val out = ArrayList<IntRange>()
+        for (m in URB_RE.findAll(text)) {
+            var end = m.range.last
+            while (end > m.range.first) {
+                val c = text[end]
+                val trimmable = c in TRAILING_TRIM ||
+                    (c == ')' && '(' !in text.substring(m.range.first, end + 1))
+                if (trimmable) end-- else break
+            }
+            // Must have at least one char after the scheme to be a link.
+            if (end - m.range.first + 1 > SCHEME.length) {
+                out.add(m.range.first..end)
+            }
+        }
+        return out
+    }
+
+    /** Extract the urb:// substrings of [text], in order. */
+    fun extract(text: String): List<String> =
+        findRanges(text).map { text.substring(it.first, it.last + 1) }
+}

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/UrbLinkLauncher.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/UrbLinkLauncher.kt
@@ -1,0 +1,46 @@
+package io.nisfeb.talon.urbit
+
+/**
+ * Hands a `urb://` link off to Lattice (the Urbit gemtext browser), if
+ * it's installed. Same-shape interface in commonMain with a platform
+ * impl per leaf, mirroring [io.nisfeb.talon.notify.Notifier].
+ *
+ *  - Android: resolves an `ACTION_VIEW` intent for the urb:// scheme.
+ *    A null resolution means no app registered the scheme → NotInstalled.
+ *  - Desktop: queries the OS scheme handler (xdg-mime on Linux) and
+ *    shells out to the platform opener (xdg-open / open / rundll32).
+ *
+ * Callers render urb:// links tappable unconditionally and resolve
+ * installed-or-not at tap time via [open] — there's no pre-detection
+ * styling pass, so a freshly-installed Lattice works without Talon
+ * re-rendering.
+ */
+interface UrbLinkLauncher {
+    fun open(url: String): UrbLaunchResult
+
+    companion object {
+        /** Where to send users who tap a urb:// link with no Lattice
+         *  installed. The install-prompt dialog links here. */
+        const val INSTALL_URL = "https://github.com/nisfeb/lattice/releases/latest"
+    }
+}
+
+enum class UrbLaunchResult {
+    /** Lattice (or some urb:// handler) accepted the link. */
+    Opened,
+
+    /** No app on the device handles the urb:// scheme. */
+    NotInstalled,
+
+    /** A handler exists but the launch attempt errored. */
+    Failed,
+}
+
+/**
+ * Default no-op used by tests and any leaf that hasn't wired a real
+ * launcher. Always reports [UrbLaunchResult.NotInstalled] so the UI
+ * degrades to the install prompt rather than silently swallowing taps.
+ */
+object NoopUrbLinkLauncher : UrbLinkLauncher {
+    override fun open(url: String): UrbLaunchResult = UrbLaunchResult.NotInstalled
+}

--- a/composeApp/src/commonTest/kotlin/io/nisfeb/talon/urbit/UrbLinkTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/nisfeb/talon/urbit/UrbLinkTest.kt
@@ -1,0 +1,80 @@
+package io.nisfeb.talon.urbit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UrbLinkTest {
+
+    @Test
+    fun isUrbUrlAcceptsWellFormed() {
+        assertTrue(UrbLink.isUrbUrl("urb://~sampel-palnet/notes/hello.gmi"))
+        assertTrue(UrbLink.isUrbUrl("urb://~zod/"))
+        assertTrue(UrbLink.isUrbUrl("  urb://~zod/a/b  ")) // trimmed
+    }
+
+    @Test
+    fun isUrbUrlRejectsJunk() {
+        assertFalse(UrbLink.isUrbUrl("urb://"))            // scheme only
+        assertFalse(UrbLink.isUrbUrl("https://example.com"))
+        assertFalse(UrbLink.isUrbUrl("urb://~zod a"))      // embedded space
+        assertFalse(UrbLink.isUrbUrl("see urb://~zod/x"))  // surrounding text
+    }
+
+    @Test
+    fun extractsBareUrlFromText() {
+        val text = "check out urb://~sampel-palnet/page.gmi it's great"
+        assertEquals(listOf("urb://~sampel-palnet/page.gmi"), UrbLink.extract(text))
+    }
+
+    @Test
+    fun extractsMultiple() {
+        val text = "urb://~zod/a and urb://~nec/b"
+        assertEquals(listOf("urb://~zod/a", "urb://~nec/b"), UrbLink.extract(text))
+    }
+
+    @Test
+    fun trimsTrailingSentencePunctuation() {
+        assertEquals(listOf("urb://~zod/page"), UrbLink.extract("go to urb://~zod/page."))
+        assertEquals(listOf("urb://~zod/page"), UrbLink.extract("urb://~zod/page!"))
+        assertEquals(listOf("urb://~zod/a/b"), UrbLink.extract("(urb://~zod/a/b),"))
+    }
+
+    @Test
+    fun keepsBalancedParens() {
+        // A closing paren that pairs with one inside the URL stays.
+        assertEquals(
+            listOf("urb://~zod/a(b)"),
+            UrbLink.extract("urb://~zod/a(b)"),
+        )
+        // A closing paren with no opener inside the URL is trimmed
+        // (it's the wrapping prose paren).
+        assertEquals(
+            listOf("urb://~zod/a"),
+            UrbLink.extract("(urb://~zod/a)"),
+        )
+    }
+
+    @Test
+    fun excludesQuotesAndAngles() {
+        assertEquals(listOf("urb://~zod/a"), UrbLink.extract("\"urb://~zod/a\""))
+        assertEquals(listOf("urb://~zod/a"), UrbLink.extract("<urb://~zod/a>"))
+    }
+
+    @Test
+    fun noFalsePositives() {
+        assertTrue(UrbLink.extract("just some text, no links").isEmpty())
+        assertTrue(UrbLink.extract("https://example.com/urb").isEmpty())
+        assertTrue(UrbLink.extract("urb:// ").isEmpty()) // scheme only, then space
+    }
+
+    @Test
+    fun rangesPointIntoOriginal() {
+        val text = "x urb://~zod/p y"
+        val ranges = UrbLink.findRanges(text)
+        assertEquals(1, ranges.size)
+        val r = ranges[0]
+        assertEquals("urb://~zod/p", text.substring(r.first, r.last + 1))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/io/nisfeb/talon/compose/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/io/nisfeb/talon/compose/Main.kt
@@ -391,6 +391,7 @@ fun main() {
                         io.nisfeb.talon.ui.DesktopMenuSeenStore(ship = ship)
                     },
                     lastOpenChatStore = graph.lastOpenChatStore,
+                    urbLinkLauncher = io.nisfeb.talon.urbit.DesktopUrbLinkLauncher,
                 )
             }
         }

--- a/composeApp/src/desktopMain/kotlin/io/nisfeb/talon/urbit/DesktopUrbLinkLauncher.kt
+++ b/composeApp/src/desktopMain/kotlin/io/nisfeb/talon/urbit/DesktopUrbLinkLauncher.kt
@@ -1,0 +1,81 @@
+package io.nisfeb.talon.urbit
+
+import io.nisfeb.talon.util.Log
+
+/**
+ * Desktop [UrbLinkLauncher]. Detects a registered urb:// scheme
+ * handler and opens via the platform opener.
+ *
+ *  - Linux: `xdg-mime query default x-scheme-handler/urb` returns the
+ *    handler .desktop file (empty when none) — a reliable installed
+ *    check. Open with `xdg-open`, the same path
+ *    [io.nisfeb.talon.ui.DesktopUriHandler] uses (works under X11 and
+ *    Wayland alike).
+ *  - macOS / Windows: scheme-handler detection is unreliable without
+ *    deeper OS APIs, so we attempt the open best-effort and report
+ *    [UrbLaunchResult.Opened]. If nothing is registered the OS shows
+ *    its own "no app" affordance — acceptable on these smaller
+ *    desktop cohorts, and the link is always copyable.
+ */
+object DesktopUrbLinkLauncher : UrbLinkLauncher {
+    private const val TAG = "UrbLinkLauncher"
+    private val osName = System.getProperty("os.name", "").lowercase()
+
+    override fun open(url: String): UrbLaunchResult = when {
+        "linux" in osName -> openLinux(url)
+        "mac" in osName || "darwin" in osName -> openBestEffort(url, arrayOf("open", url))
+        "windows" in osName ->
+            openBestEffort(url, arrayOf("rundll32", "url.dll,FileProtocolHandler", url))
+        else -> openBestEffort(url, null)
+    }
+
+    private fun openLinux(url: String): UrbLaunchResult {
+        if (!hasLinuxHandler()) return UrbLaunchResult.NotInstalled
+        return if (run(arrayOf("xdg-open", url))) UrbLaunchResult.Opened
+        else UrbLaunchResult.Failed
+    }
+
+    private fun hasLinuxHandler(): Boolean = runCatching {
+        val proc = ProcessBuilder("xdg-mime", "query", "default", "x-scheme-handler/urb")
+            .redirectErrorStream(true)
+            .start()
+        val out = proc.inputStream.bufferedReader().readText().trim()
+        proc.waitFor()
+        out.isNotEmpty()
+    }.getOrElse {
+        Log.w(TAG, "xdg-mime query failed: ${it.message}")
+        // If we can't even run xdg-mime, fall back to "attempt anyway"
+        // rather than falsely reporting NotInstalled.
+        true
+    }
+
+    private fun openBestEffort(url: String, cmd: Array<String>?): UrbLaunchResult {
+        if (cmd != null && run(cmd)) return UrbLaunchResult.Opened
+        // Last-resort AWT browse for an unrecognised OS.
+        return runCatching {
+            val desktop = java.awt.Desktop.getDesktop()
+            if (java.awt.Desktop.isDesktopSupported() &&
+                desktop.isSupported(java.awt.Desktop.Action.BROWSE)
+            ) {
+                desktop.browse(java.net.URI(url))
+                UrbLaunchResult.Opened
+            } else {
+                UrbLaunchResult.Failed
+            }
+        }.getOrElse {
+            Log.w(TAG, "best-effort open failed for $url: ${it.message}")
+            UrbLaunchResult.Failed
+        }
+    }
+
+    private fun run(cmd: Array<String>): Boolean = runCatching {
+        ProcessBuilder(*cmd)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        true
+    }.getOrElse {
+        Log.w(TAG, "opener ${cmd.firstOrNull()} failed: ${it.message}")
+        false
+    }
+}


### PR DESCRIPTION
Talon detects `urb://~ship/path` addresses in chat and opens them in [Lattice](https://github.com/nisfeb/lattice) (the peer-to-peer Urbit gemtext browser) when installed, prompting to install when not.

## What's here
- **`UrbLink`** (commonMain, 9 tests) — finds + validates `urb://` runs in free text (trailing-punctuation trim, balanced parens, quote/angle exclusion, multi-match). Tlon only linkifies http(s), so `urb://` arrives as plain text; `Story.kt` now autolinks it under the same `URL_TAG` http links use.
- **`UrbLinkLauncher`** — same-shape interface + `NoopUrbLinkLauncher`, impl per leaf:
  - Android: `queryIntentActivities` → `startActivity(ACTION_VIEW)`
  - Desktop: `xdg-mime` scheme-handler detect + `xdg-open` (Linux); best-effort `open`/`rundll32` on mac/win
  - Returns `Opened` / `NotInstalled` / `Failed`
- **`LocalUrbLinkHandler`** composition local + **`InstallLatticeDialog`** — chat screens' `onLinkTap` branches on the `urb://` prefix; `NotInstalled` raises a prompt linking to Lattice releases. Wired at the app root on desktop (`App.kt`/`Main.kt`) and Android (`TalonApp.kt`).

## Verification
- Both targets compile; `desktopTest` (incl. `UrbLinkTest`) + icon audit pass; desktop boots clean.
- **Not verified (no hardware here):** the actual cross-app tap→open on a device, and macOS specifically. Pairs with the receiving side in nisfeb/lattice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)