### PR TITLE
Fix presigned-url uploads, stale notification relaunch, + desktop edit shortcuts

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/nisfeb/talon/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/io/nisfeb/talon/MainActivity.kt
@@ -48,7 +48,18 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        consumeIntent(intent)
+        // Only consume the launch intent's deep-link extras on a genuine
+        // fresh start. A notification tap routes through onNewIntent and
+        // setIntent(), so the notification intent (with EXTRA_OPEN_WHOM /
+        // EXTRA_SCROLL_TO_MESSAGE) becomes the task's sticky intent. When
+        // the OS later kills the backgrounded process and the user
+        // reopens — especially from Recents — the activity is recreated
+        // with savedInstanceState != null and getIntent() still returns
+        // that old notification intent. Re-consuming it yanked the user
+        // back to a week-old message on every reopen (the reported bug).
+        // A real notification tap on a dead process is a fresh start
+        // (savedInstanceState == null), so it still routes correctly.
+        if (savedInstanceState == null) consumeIntent(intent)
 
         // Android 13+ gates notifications behind a runtime prompt.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -160,20 +171,42 @@ class MainActivity : ComponentActivity() {
 
     private fun consumeIntent(intent: Intent?) {
         if (intent == null) return
+        var consumedDeepLink = false
         intent.getStringExtra(Notifications.EXTRA_OPEN_WHOM)?.let {
             deepLinkWhom.value = it
+            consumedDeepLink = true
         }
         intent.getStringExtra(Notifications.EXTRA_SCROLL_TO_MESSAGE)?.let {
             deepLinkMessageId.value = it
+            consumedDeepLink = true
         }
         intent.getStringExtra(Notifications.EXTRA_OPEN_THREAD)?.let {
             deepLinkThreadParent.value = it
+            consumedDeepLink = true
         }
         intent.getStringExtra(Notifications.EXTRA_THREAD_ANCHOR)?.let {
             deepLinkThreadAnchor.value = it
+            consumedDeepLink = true
         }
         intent.getStringExtra(Notifications.EXTRA_OPEN_DIGEST)?.let {
             deepLinkOpenDigest.value = it
+            consumedDeepLink = true
+        }
+        // Strip the deep-link extras now that we've read them, then write
+        // the cleaned intent back as the activity's intent. The task
+        // retains its current intent across a process kill; without this,
+        // getIntent() would keep handing back the same notification
+        // payload and re-route to a stale message on the next launch
+        // (belt-and-suspenders with the savedInstanceState guard in
+        // onCreate). Only the deep-link extras are cleared — share
+        // routing below is a transient ACTION_SEND intent, not retained.
+        if (consumedDeepLink) {
+            intent.removeExtra(Notifications.EXTRA_OPEN_WHOM)
+            intent.removeExtra(Notifications.EXTRA_SCROLL_TO_MESSAGE)
+            intent.removeExtra(Notifications.EXTRA_OPEN_THREAD)
+            intent.removeExtra(Notifications.EXTRA_THREAD_ANCHOR)
+            intent.removeExtra(Notifications.EXTRA_OPEN_DIGEST)
+            setIntent(intent)
         }
         ShareIntent.from(intent)?.let {
             pendingShare.value = it

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/ChatComposer.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/ChatComposer.kt
@@ -150,6 +150,11 @@ fun ChatComposer(
      *  poking. Caller threads `uiSettings.powerFeaturesEnabled`
      *  through. */
     powerFeaturesEnabled: Boolean = false,
+    /** Up-arrow-on-empty-composer hook: edit your most recently sent
+     *  message (Slack/Discord convenience for hardware keyboards). Null
+     *  where editing isn't supported (e.g. %chat DMs), in which case Up
+     *  keeps its normal caret behaviour. */
+    onEditLast: (() -> Unit)? = null,
     /** Caller-side hook fired right before the optimistic upsert
      *  lands. DM uses this to capture its scroll baseline + bump
      *  the force-bottom tick so its self-send-scroll heuristic sees
@@ -538,6 +543,17 @@ fun ChatComposer(
                             } else {
                                 (emojiSel - 1).coerceAtLeast(0)
                             }
+                            return@onPreviewKeyEvent true
+                        }
+                        // Up arrow on an empty composer jumps straight into
+                        // editing your most recently sent message (matches
+                        // Slack/Discord). Gated on an empty draft so Up
+                        // still moves the caret while you're typing, and on
+                        // onEditLast being wired (channel chats only).
+                        if (e.key == Key.DirectionUp && onEditLast != null &&
+                            state.draft.text.isEmpty()
+                        ) {
+                            onEditLast()
                             return@onPreviewKeyEvent true
                         }
                         // Tab accepts the highlighted autocomplete

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmChatScreen.kt
@@ -963,6 +963,21 @@ fun DmChatScreen(
                 voicePlayer = voicePlayer,
                 onSlashMic = onSlashMic,
                 powerFeaturesEnabled = powerFeaturesEnabled,
+                // Up-arrow-on-empty-composer edits your most recent
+                // message. Same predicate as the Edit menu action
+                // (mine, channel chat, top-level) so it can only open
+                // an edit the action menu would also allow. Null on
+                // non-channel chats — %chat DMs ignore edit pokes.
+                onEditLast = if (whom.startsWith("chat/")) {
+                    {
+                        rows.asSequence()
+                            .filterIsInstance<ChatListItem.Message>()
+                            .map { it.row.m }
+                            .filter { it.author == ourPatp && it.parentId == null }
+                            .maxByOrNull { it.sentMs }
+                            ?.let { editing = it }
+                    }
+                } else null,
                 onBeforeLocalEcho = {
                     // Capture the row count synchronously BEFORE the
                     // optimistic upsert can land, then bump the
@@ -1748,19 +1763,49 @@ private fun EditMessageDialog(
     onDismiss: () -> Unit,
     onSave: (String) -> Unit,
 ) {
-    var text by remember { mutableStateOf(initial) }
+    // TextFieldValue (not a bare String) so Shift+Enter can splice a
+    // newline in at the caret. Caret starts at the end so the user can
+    // immediately type or hit Return to save.
+    var value by remember {
+        mutableStateOf(TextFieldValue(initial, selection = TextRange(initial.length)))
+    }
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focus.requestFocus() }
+    val submit = { if (value.text.isNotBlank()) onSave(value.text.trim()) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Edit message") },
         text = {
             OutlinedTextField(
-                value = text,
-                onValueChange = { text = it },
-                modifier = Modifier.fillMaxWidth(),
+                value = value,
+                onValueChange = { value = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focus)
+                    .onPreviewKeyEvent { e ->
+                        // Return sends the edit; Shift+Return inserts a
+                        // newline (CMP Desktop won't on a hardware Return,
+                        // so splice it in ourselves). Mirrors the composer.
+                        if (e.type != KeyEventType.KeyDown || e.key != Key.Enter) {
+                            return@onPreviewKeyEvent false
+                        }
+                        if (e.isShiftPressed) {
+                            val sel = value.selection
+                            val newText = value.text.substring(0, sel.start) +
+                                "\n" + value.text.substring(sel.end)
+                            value = value.copy(
+                                text = newText,
+                                selection = TextRange(sel.start + 1),
+                            )
+                        } else {
+                            submit()
+                        }
+                        true
+                    },
             )
         },
         confirmButton = {
-            TextButton(onClick = { onSave(text.trim()) }, enabled = text.isNotBlank()) {
+            TextButton(onClick = submit, enabled = value.text.isNotBlank()) {
                 Text("Save")
             }
         },

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/StorageUpload.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/StorageUpload.kt
@@ -1,0 +1,77 @@
+package io.nisfeb.talon.urbit
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Parsing + the upload-mode decision for the %storage agent's S3 config.
+ *
+ * Talon uploads via a direct AWS SigV4 PUT (see [S3Uploader]) whenever
+ * the agent exposes full credentials, mirroring tlon-apps' `hasCustomS3Creds`
+ * (packages/shared/src/store/storage/storageUtils.ts). The agent's
+ * `service` field (`credentials` | `presigned-url`) only steers
+ * *Tlon-hosted* ships to the memex uploader — which [TlonChatRepo]
+ * already tries first. For a self-hosted ship the reference client
+ * ignores `service` and signs directly, so we must NOT gate on it: a
+ * ship with valid credentials but `service` set to `presigned-url` (the
+ * ~dinnyt-divsud report) uploads fine once we stop rejecting it.
+ */
+internal data class StorageCreds(
+    val endpoint: String,
+    val accessKeyId: String,
+    val secretAccessKey: String,
+)
+
+internal data class StorageConfig(
+    val bucket: String,
+    val region: String,
+    val publicUrlBase: String?,
+    /** `credentials` | `presigned-url` | null. Informational only — does
+     *  not gate the credentials upload path; see [storageS3Ready]. */
+    val service: String?,
+)
+
+internal fun parseStorageCredentials(body: JsonElement?): StorageCreds? {
+    // %storage returns {"storage-update": {"credentials": {...}}}; field
+    // names may be kebab-case or camelCase depending on the agent version.
+    val obj = (body as? JsonObject) ?: return null
+    val inner = (obj["storage-update"] as? JsonObject)?.get("credentials") as? JsonObject
+        ?: (obj["credentials"] as? JsonObject)
+        ?: obj
+    val endpoint = inner["endpoint"].asStr() ?: ""
+    val accessKeyId = inner["access-key-id"].asStr()
+        ?: inner["accessKeyId"].asStr()
+        ?: ""
+    val secretAccessKey = inner["secret-access-key"].asStr()
+        ?: inner["secretAccessKey"].asStr()
+        ?: ""
+    return StorageCreds(endpoint, accessKeyId, secretAccessKey)
+}
+
+internal fun parseStorageConfiguration(body: JsonElement?): StorageConfig? {
+    val obj = (body as? JsonObject) ?: return null
+    val inner = (obj["storage-update"] as? JsonObject)?.get("configuration") as? JsonObject
+        ?: (obj["configuration"] as? JsonObject)
+        ?: obj
+    val bucket = inner["current-bucket"].asStr()
+        ?: inner["currentBucket"].asStr()
+        ?: ""
+    val region = inner["region"].asStr() ?: ""
+    val publicUrlBase = inner["public-url-base"].asStr()
+        ?: inner["publicUrlBase"].asStr()
+    val service = inner["service"].asStr()
+    return StorageConfig(bucket, region, publicUrlBase, service)
+}
+
+/**
+ * True when the agent exposes everything [S3Uploader] needs for a direct
+ * SigV4 PUT — endpoint, access key, secret, and a bucket. Deliberately
+ * independent of [StorageConfig.service]: the credentials path is valid
+ * in either mode, and gating on `service == "credentials"` was the bug
+ * that broke uploads for ships left in `presigned-url` mode.
+ */
+internal fun storageS3Ready(creds: StorageCreds, config: StorageConfig): Boolean =
+    creds.endpoint.isNotBlank() &&
+        creds.accessKeyId.isNotBlank() &&
+        creds.secretAccessKey.isNotBlank() &&
+        config.bucket.isNotBlank()

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
@@ -1803,13 +1803,23 @@ class TlonChatRepo(
             ?: error("no %storage credentials on this ship")
         val config = parseStorageConfiguration(configElement)
             ?: error("no %storage configuration on this ship")
-        if (!config.service.isNullOrEmpty() && config.service != "credentials") {
-            error("%storage is in '${config.service}' mode; only 'credentials' is supported")
-        }
-        if (creds.accessKeyId.isBlank() || creds.secretAccessKey.isBlank() ||
-            creds.endpoint.isBlank() || config.bucket.isBlank()
-        ) {
-            error("%storage credentials not fully configured")
+        // Upload via direct S3 whenever the agent has full credentials,
+        // regardless of the `service` mode — matching tlon-apps. We do NOT
+        // reject `presigned-url` mode: that field only routes Tlon-hosted
+        // ships to memex (already tried above), and gating on it here was
+        // what blocked ships left in presigned-url mode but holding valid
+        // creds (the ~dinnyt-divsud report). See StorageUpload.kt.
+        if (!storageS3Ready(creds, config)) {
+            error(
+                if (config.service == "presigned-url") {
+                    "%storage is in presigned-url mode with no S3 credentials. " +
+                        "Talon uploads need direct credentials — add them in " +
+                        "Landscape's storage settings, or switch the agent with " +
+                        "`:storage &storage-action [%toggle-service %credentials]`."
+                } else {
+                    "%storage credentials not fully configured"
+                },
+            )
         }
 
         val safeName = fileName.replace(Regex("[^A-Za-z0-9._-]"), "_")
@@ -1831,51 +1841,6 @@ class TlonChatRepo(
             bytes = bytes,
             contentType = contentType,
         )
-    }
-
-    private data class StorageCreds(
-        val endpoint: String,
-        val accessKeyId: String,
-        val secretAccessKey: String,
-    )
-
-    private data class StorageConfig(
-        val bucket: String,
-        val region: String,
-        val publicUrlBase: String?,
-        val service: String?,
-    )
-
-    private fun parseStorageCredentials(body: JsonElement?): StorageCreds? {
-        // %storage returns {"storage-update": {"credentials": {...}}}; field
-        // names may be kebab-case or camelCase depending on the agent version.
-        val obj = (body as? JsonObject) ?: return null
-        val inner = (obj["storage-update"] as? JsonObject)?.get("credentials") as? JsonObject
-            ?: (obj["credentials"] as? JsonObject)
-            ?: obj
-        val endpoint = inner["endpoint"].asStr() ?: ""
-        val accessKeyId = inner["access-key-id"].asStr()
-            ?: inner["accessKeyId"].asStr()
-            ?: ""
-        val secretAccessKey = inner["secret-access-key"].asStr()
-            ?: inner["secretAccessKey"].asStr()
-            ?: ""
-        return StorageCreds(endpoint, accessKeyId, secretAccessKey)
-    }
-
-    private fun parseStorageConfiguration(body: JsonElement?): StorageConfig? {
-        val obj = (body as? JsonObject) ?: return null
-        val inner = (obj["storage-update"] as? JsonObject)?.get("configuration") as? JsonObject
-            ?: (obj["configuration"] as? JsonObject)
-            ?: obj
-        val bucket = inner["current-bucket"].asStr()
-            ?: inner["currentBucket"].asStr()
-            ?: ""
-        val region = inner["region"].asStr() ?: ""
-        val publicUrlBase = inner["public-url-base"].asStr()
-            ?: inner["publicUrlBase"].asStr()
-        val service = inner["service"].asStr()
-        return StorageConfig(bucket, region, publicUrlBase, service)
     }
 
     /**

--- a/composeApp/src/commonTest/kotlin/io/nisfeb/talon/urbit/StorageUploadTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/nisfeb/talon/urbit/StorageUploadTest.kt
@@ -1,0 +1,120 @@
+package io.nisfeb.talon.urbit
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins %storage parsing + the upload-mode decision. The regression that
+ * motivated this: a ship with valid S3 credentials but `service` set to
+ * `presigned-url` (~dinnyt-divsud) was rejected, even though the
+ * credentials upload path works in either mode — matching tlon-apps'
+ * `hasCustomS3Creds`, which never looks at `service`.
+ */
+class StorageUploadTest {
+
+    private fun json(s: String) = Json.parseToJsonElement(s)
+
+    // ─── credentials parsing ──────────────────────────────────────
+
+    @Test
+    fun `parses kebab-case credentials wrapped in storage-update`() {
+        val creds = parseStorageCredentials(
+            json(
+                """
+                {"storage-update": {"credentials": {
+                    "endpoint": "https://s3.example.com",
+                    "access-key-id": "AKIA",
+                    "secret-access-key": "shhh"
+                }}}
+                """.trimIndent(),
+            ),
+        )
+        assertEquals("https://s3.example.com", creds?.endpoint)
+        assertEquals("AKIA", creds?.accessKeyId)
+        assertEquals("shhh", creds?.secretAccessKey)
+    }
+
+    @Test
+    fun `parses camelCase credentials at the root`() {
+        val creds = parseStorageCredentials(
+            json(
+                """{"endpoint":"e","accessKeyId":"k","secretAccessKey":"s"}""",
+            ),
+        )
+        assertEquals("e", creds?.endpoint)
+        assertEquals("k", creds?.accessKeyId)
+        assertEquals("s", creds?.secretAccessKey)
+    }
+
+    // ─── configuration parsing ────────────────────────────────────
+
+    @Test
+    fun `parses configuration including the presigned-url service field`() {
+        val config = parseStorageConfiguration(
+            json(
+                """
+                {"storage-update": {"configuration": {
+                    "current-bucket": "media",
+                    "region": "us-west-2",
+                    "public-url-base": "https://cdn.example.com",
+                    "service": "presigned-url"
+                }}}
+                """.trimIndent(),
+            ),
+        )
+        assertEquals("media", config?.bucket)
+        assertEquals("us-west-2", config?.region)
+        assertEquals("https://cdn.example.com", config?.publicUrlBase)
+        assertEquals("presigned-url", config?.service)
+    }
+
+    @Test
+    fun `non-object body parses to null`() {
+        assertNull(parseStorageCredentials(json("\"nope\"")))
+        assertNull(parseStorageConfiguration(json("42")))
+    }
+
+    // ─── the fix: service mode does not gate the credentials path ──
+
+    @Test
+    fun `presigned-url mode with full credentials is upload-ready`() {
+        // The regression. Full creds present, service = presigned-url —
+        // must still be ready (tlon-apps ignores `service` here).
+        val creds = StorageCreds("https://s3.example.com", "AKIA", "shhh")
+        val config = StorageConfig("media", "us-east-1", null, "presigned-url")
+        assertTrue(storageS3Ready(creds, config))
+    }
+
+    @Test
+    fun `credentials mode with full credentials is upload-ready`() {
+        val creds = StorageCreds("https://s3.example.com", "AKIA", "shhh")
+        val config = StorageConfig("media", "us-east-1", null, "credentials")
+        assertTrue(storageS3Ready(creds, config))
+    }
+
+    @Test
+    fun `missing service is upload-ready when credentials are present`() {
+        val creds = StorageCreds("https://s3.example.com", "AKIA", "shhh")
+        val config = StorageConfig("media", "us-east-1", null, null)
+        assertTrue(storageS3Ready(creds, config))
+    }
+
+    @Test
+    fun `blank credentials are not upload-ready regardless of mode`() {
+        val config = StorageConfig("media", "us-east-1", null, "credentials")
+        assertFalse(storageS3Ready(StorageCreds("", "AKIA", "shhh"), config))
+        assertFalse(storageS3Ready(StorageCreds("e", "", "shhh"), config))
+        assertFalse(storageS3Ready(StorageCreds("e", "AKIA", ""), config))
+    }
+
+    @Test
+    fun `a blank bucket is not upload-ready`() {
+        val creds = StorageCreds("https://s3.example.com", "AKIA", "shhh")
+        val config = StorageConfig("", "us-east-1", null, "presigned-url")
+        assertFalse(storageS3Ready(creds, config))
+    }
+}


### PR DESCRIPTION
Three fixes queued for the next release. Independent commits; safe to review separately.

## 1. `fix(upload)` — don't reject %storage presigned-url mode when credentials exist
`uploadViaStorage` rejected any `%storage` config whose `service` wasn't `credentials`, so a ship left in **presigned-url mode but holding valid S3 credentials** (the ~dinnyt-divsud report) couldn't upload — even though the upload would have worked.

Checked against tlon-apps' reference client (`storageActions.ts` / `storageUtils.ts`): it never gates on `service` for the credentials path — it uploads via direct S3 whenever the agent exposes credentials (`hasCustomS3Creds`). `service` only steers *Tlon-hosted* ships to the memex uploader, which we already try first. So there is no separate self-hosted "presigned-url HTTP service" to implement; the fix is to **stop rejecting**.

- Drop the service-mode gate; key off credential presence instead.
- Extract parsing + the decision into a testable `StorageUpload.kt` (`storageS3Ready`).
- A genuinely cred-less presigned-url ship now gets an actionable error (add creds, or `:storage &storage-action [%toggle-service %credentials]`).

## 2. `fix(android)` — stop reopening to a stale notification deep link
A notification tap routes through `onNewIntent` + `setIntent()`, so the notification intent (`EXTRA_OPEN_WHOM` / `EXTRA_SCROLL_TO_MESSAGE`) becomes the task's sticky intent and was never stripped. `onCreate` consumed `getIntent()` unconditionally, so after the OS killed the backgrounded process, reopening (especially from Recents) **replayed a week-old deep link** and yanked the user to an old message — overriding the 0.13.0 last-open-chat restore.

- Only consume the launch intent on a genuine fresh start (`savedInstanceState == null`).
- Strip the deep-link extras after reading them (write the cleaned intent back via `setIntent`) so the retained task intent can't re-fire.
- A real notification tap on a dead process is still a fresh start, so deep-linking keeps working.

## 3. `feat(desktop)` — up-arrow edits last message; Enter sends an edit
- **Up arrow on an empty composer** opens the edit form for your most recently sent message (new optional `onEditLast` hook on `ChatComposer`; gated on empty draft, placed after emoji-picker arrow handling). The DM screen selects the latest top-level message you authored, matching the Edit menu's predicate; `null` on `%chat` DMs where edits aren't supported.
- **Edit dialog: Return sends, Shift+Return inserts a newline** (was a plain single-field dialog). Switched to `TextFieldValue` with the composer's key handling, autofocused with the caret at the end.

## Testing
- `storageS3Ready` + parsing covered by new `StorageUploadTest` (commonTest) — incl. the regression: presigned-url mode + full creds ⇒ upload-ready.
- Full `desktopTest` suite passes; common + desktop + Android all compile.
- Desktop app smoke-launched clean (channel chat + DM mounted, no exceptions).

### Related issues
- **Closes #2 (Android)** is activity-lifecycle behavior — not reachable from `desktopTest`/`commonTest` and no instrumentation harness here. Verify on-device: tap a notification → background → force-stop → reopen from launcher **and** Recents (should land on last-seen view, not the old message); then tap a fresh notification (should still deep-link).
- **#3 (desktop)** keypresses couldn't be simulated under XWayland here. Verify: in a channel chat, ↑ on an empty box opens the edit dialog; Enter saves, Shift+Enter newlines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
