### PR TITLE
Sync status-feed "seen" state across devices

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
@@ -1394,6 +1394,12 @@ fun App(
                         // queries is the trade-off — cheap, and lets each
                         // call site stay self-contained.
                         val menuSeenState by menuSeen.state.collectAsState()
+                        // Cross-device status-seen marker (see DmListScreen).
+                        val railStatusesSeenFlow = remember(repo) {
+                            repo.settingsSync?.statusesSeenMs
+                                ?: kotlinx.coroutines.flow.MutableStateFlow(0L)
+                        }
+                        val railSyncedStatusesSeenMs by railStatusesSeenFlow.collectAsState()
                         val railPendingInvites = repo.invitesFlow.collectAsState().value
                             ?: emptyList()
                         val railLatestDigest by remember(db, ship) {
@@ -1405,13 +1411,15 @@ fun App(
                         val railInvitesSnapshot = remember(railPendingInvites) {
                             invitesSnapshot(railPendingInvites.map { it.flag })
                         }
+                        val railEffectiveStatusesSeenMs =
+                            maxOf(menuSeenState.lastSeenStatusesMs, railSyncedStatusesSeenMs)
                         val menuBadges = remember(
                             railLatestDigest, railStatusFeed, railPendingInvites,
-                            railInvitesSnapshot, menuSeenState, ship,
+                            railInvitesSnapshot, menuSeenState, railEffectiveStatusesSeenMs, ship,
                         ) {
                             MenuBadges(
                                 statusesFresh = railStatusFeed.any { c ->
-                                    (c.statusUpdatedMs ?: 0L) > menuSeenState.lastSeenStatusesMs &&
+                                    (c.statusUpdatedMs ?: 0L) > railEffectiveStatusesSeenMs &&
                                         !c.status.isNullOrBlank() &&
                                         c.ship != ship
                                 },
@@ -1429,8 +1437,13 @@ fun App(
                             // DmListScreen already had, so the dot lingered
                             // until the user opened the kebab.
                             when (item) {
-                                RailItem.Statuses ->
-                                    menuSeen.markStatusesSeenAt(System.currentTimeMillis())
+                                RailItem.Statuses -> {
+                                    val now = System.currentTimeMillis()
+                                    menuSeen.markStatusesSeenAt(now)
+                                    repo.pushScope.launch {
+                                        runCatching { repo.settingsSync?.pushStatusesSeen(now) }
+                                    }
+                                }
                                 RailItem.TodaysBrief ->
                                     railLatestDigest?.dateLocal?.let { menuSeen.markDigestSeen(it) }
                                 RailItem.Invites ->

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmListScreen.kt
@@ -707,6 +707,14 @@ fun DmListScreen(
             // exactly that). The marker writes happen in the per-item
             // onClick branches below.
             val seenState by menuSeen.state.collectAsState()
+            // Status-feed "seen" syncs across the user's devices via
+            // %settings; merge that high-water mark with the local one so
+            // viewing statuses on any device clears the fresh dot on all.
+            val statusesSeenFlow = remember(repo) {
+                repo.settingsSync?.statusesSeenMs
+                    ?: kotlinx.coroutines.flow.MutableStateFlow(0L)
+            }
+            val syncedStatusesSeenMs by statusesSeenFlow.collectAsState()
             val pendingInvites = repo.invitesFlow.collectAsState().value
                 ?: emptyList()
             val latestDigest by remember(db, activeShip) {
@@ -721,9 +729,11 @@ fun DmListScreen(
             val hasFreshDigest = latestDigest?.dateLocal?.let {
                 it != seenState.lastSeenDigestDate
             } == true
-            val hasFreshStatuses = remember(statusFeedRows, seenState.lastSeenStatusesMs, activeShip) {
+            val effectiveStatusesSeenMs =
+                maxOf(seenState.lastSeenStatusesMs, syncedStatusesSeenMs)
+            val hasFreshStatuses = remember(statusFeedRows, effectiveStatusesSeenMs, activeShip) {
                 statusFeedRows.any { c ->
-                    (c.statusUpdatedMs ?: 0L) > seenState.lastSeenStatusesMs &&
+                    (c.statusUpdatedMs ?: 0L) > effectiveStatusesSeenMs &&
                         !c.status.isNullOrBlank() &&
                         c.ship != activeShip
                 }
@@ -777,7 +787,11 @@ fun DmListScreen(
                             },
                             onClick = {
                                 menuOpen = false
-                                menuSeen.markStatusesSeenAt(System.currentTimeMillis())
+                                val now = System.currentTimeMillis()
+                                menuSeen.markStatusesSeenAt(now)
+                                repo.pushScope.launch {
+                                    runCatching { repo.settingsSync?.pushStatusesSeen(now) }
+                                }
                                 onOpenStatusFeed()
                             },
                         )

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/SettingsSync.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/SettingsSync.kt
@@ -1,6 +1,12 @@
 package io.nisfeb.talon.urbit
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.json.JsonObject
+
+/** Shared empty flow for the [SettingsSync.statusesSeenMs] default. */
+private val ZERO_STATUSES_SEEN: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
 
 /**
  * Narrow interface — the slice of the rich [SettingsSyncImpl] that
@@ -54,6 +60,20 @@ interface SettingsSync {
 
     suspend fun addBookmark(whom: String, postId: String, ts: Long) {}
     suspend fun removeBookmark(whom: String, postId: String) {}
+
+    // ───────── status-feed seen sync ─────────
+    /**
+     * High-water mark (unix-ms) of the latest time ANY of the user's
+     * devices opened the Status feed. Synced via %settings so the
+     * fresh-status dot clears on every device once seen on one. The UI
+     * maxes this with its local MenuSeenStore value; 0 until first sync.
+     */
+    val statusesSeenMs: StateFlow<Long> get() = ZERO_STATUSES_SEEN
+
+    /** Record + broadcast that the user opened the Status feed at [ms].
+     *  Other devices receive it via the %settings subscription and clear
+     *  their fresh-status dot. Default no-op for hosts that don't sync. */
+    suspend fun pushStatusesSeen(ms: Long) {}
 
     // ───────── notify level mutation ─────────
     // Persists the per-conversation notification volume locally and

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/SettingsSyncImpl.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/SettingsSyncImpl.kt
@@ -15,6 +15,9 @@ import io.nisfeb.talon.data.NotifyPreferenceEntity
 import io.nisfeb.talon.data.RailItemPrefEntity
 import io.nisfeb.talon.ui.RailItem
 import io.nisfeb.talon.ui.railItemOrNull
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.serialization.json.booleanOrNull
@@ -84,6 +87,10 @@ class SettingsSyncImpl(
         const val BUCKET_WATCHWORDS = "watchwords"
         const val BUCKET_WATCHWORD_EXCLUDES = "watchword-excludes"
         const val BUCKET_DAILY_DIGEST = "daily-digest"
+        const val BUCKET_STATUS_SEEN = "status-seen"
+        // Single-entry bucket: the seen high-water mark is global to the
+        // user, not per-anything, so one stable key holds it.
+        private const val STATUS_SEEN_ENTRY = "me"
         private const val AI_ENTRY = "config"
 
         // Wire schema version for the ai-settings entry. v1 (no
@@ -96,6 +103,25 @@ class SettingsSyncImpl(
     }
 
     @Volatile private var channel: UrbitChannel? = null
+
+    private val _statusesSeenMs = MutableStateFlow(0L)
+    override val statusesSeenMs: StateFlow<Long> = _statusesSeenMs.asStateFlow()
+
+    /** Monotonic merge: the seen marker is a high-water mark, so a stale
+     *  remote value (or the "ship wins" bootstrap) can never move a
+     *  device that's already viewed more recently backwards. */
+    private fun bumpStatusesSeen(ms: Long) {
+        if (ms > _statusesSeenMs.value) _statusesSeenMs.value = ms
+    }
+
+    override suspend fun pushStatusesSeen(ms: Long) {
+        bumpStatusesSeen(ms)
+        pokePutEntry(
+            BUCKET_STATUS_SEEN,
+            STATUS_SEEN_ENTRY,
+            buildJsonObject { put("ms", ms) },
+        )
+    }
 
     override fun attach(channel: UrbitChannel) {
         this.channel = channel
@@ -160,6 +186,7 @@ class SettingsSyncImpl(
             applyBucket(BUCKET_WATCHWORDS, deskMap[BUCKET_WATCHWORDS] as? JsonObject)
             applyBucket(BUCKET_WATCHWORD_EXCLUDES, deskMap[BUCKET_WATCHWORD_EXCLUDES] as? JsonObject)
             applyBucket(BUCKET_DAILY_DIGEST, deskMap[BUCKET_DAILY_DIGEST] as? JsonObject)
+            applyBucket(BUCKET_STATUS_SEEN, deskMap[BUCKET_STATUS_SEEN] as? JsonObject)
         }
 
         // Per-bucket recovery: catch buckets that aren't on the ship
@@ -971,6 +998,11 @@ class SettingsSyncImpl(
                 dailyDigestSettings.applyRemote(enabled, hourOfDay, minuteOfDay)
                 rearmDailyDigest()
             }
+            BUCKET_STATUS_SEEN -> {
+                val v = entries?.get(STATUS_SEEN_ENTRY) ?: return
+                val ms = (unwrap(v) as? JsonObject)?.get("ms").asLong() ?: return
+                bumpStatusesSeen(ms)
+            }
         }
     }
 
@@ -1092,6 +1124,10 @@ class SettingsSyncImpl(
                     }
                 }
                 rearmDailyDigest()
+            }
+            BUCKET_STATUS_SEEN -> {
+                val ms = (unwrapped as? JsonObject)?.get("ms").asLong() ?: return
+                bumpStatusesSeen(ms)
             }
         }
     }

--- a/composeApp/src/desktopTest/kotlin/io/nisfeb/talon/urbit/SettingsSyncApplyBucketTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/nisfeb/talon/urbit/SettingsSyncApplyBucketTest.kt
@@ -736,6 +736,48 @@ class SettingsSyncApplyBucketTest {
         assertEquals(0, dailyDigest.state.value.minuteOfDay)
         assertEquals(0, rearmCount)
     }
+
+    // ── status-seen (cross-device fresh-status marker) ──────────────
+
+    @Test
+    fun `applyBucket STATUS_SEEN publishes the marker to the flow`() = runBlocking {
+        assertEquals(0L, sync.statusesSeenMs.value)
+        val bucket = buildJsonObject {
+            put("me", buildJsonObject { put("ms", 1_700_000_000_000L) })
+        }
+        sync.applyBucket(SettingsSyncImpl.BUCKET_STATUS_SEEN, bucket)
+        assertEquals(1_700_000_000_000L, sync.statusesSeenMs.value)
+    }
+
+    @Test
+    fun `status-seen marker is monotonic — a stale value never regresses it`() = runBlocking {
+        sync.applyBucket(
+            SettingsSyncImpl.BUCKET_STATUS_SEEN,
+            buildJsonObject { put("me", buildJsonObject { put("ms", 5_000L) }) },
+        )
+        // An older remote value (e.g. a lagging device, or "ship wins"
+        // bootstrap from a stale ship copy) must not move it backwards.
+        sync.applyBucket(
+            SettingsSyncImpl.BUCKET_STATUS_SEEN,
+            buildJsonObject { put("me", buildJsonObject { put("ms", 1_000L) }) },
+        )
+        assertEquals(5_000L, sync.statusesSeenMs.value)
+    }
+
+    @Test
+    fun `put-entry event for status-seen updates the marker`() = runBlocking {
+        val payload = buildJsonObject {
+            put("put-entry", buildJsonObject {
+                put("desk", "talon")
+                put("bucket-key", SettingsSyncImpl.BUCKET_STATUS_SEEN)
+                put("entry-key", "me")
+                // Wire values are JSON-stringified cords.
+                put("value", JsonPrimitive("""{"ms":1700000000123}"""))
+            })
+        }
+        sync.applySettingsEvent(payload)
+        assertEquals(1_700_000_000_123L, sync.statusesSeenMs.value)
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The Status-feed "fresh" dot was tracked per-device (`MenuSeenStore`), so the user had to open the Status feed on **every** device to clear it.

## Change
Sync the last-seen marker over the existing `%settings` cross-device sync (desk `talon`), so viewing statuses on one device clears the dot everywhere.

- New `status-seen` bucket holding a single **high-water-mark timestamp**.
- `SettingsSync` exposes `statusesSeenMs: StateFlow<Long>` + `pushStatusesSeen(ms)`. The impl merges **monotonically** (`max`), so a stale remote value — or the "ship wins" bootstrap from a lagging ship copy — can never drag a device that viewed more recently backwards.
- Read/write reuse the established plumbing verbatim: `pokePutEntry` to write, `applyBucket`/`applyEntry` + the bootstrap scry to read, and the existing `%settings` subscription to receive other devices' updates.
- Both fresh-status read sites (home-list kebab in `DmListScreen`, desktop rail in `App.kt`) compute freshness from `max(localMenuSeen, syncedMs)`, and both open-Statuses sites push the new marker. `MenuSeenStore` is left untouched (still the local fallback).

## Why a timestamp (not per-status identity)
`statusUpdatedMs` comes from the ship's shared `mod-at` for live peer updates, so the same status carries the **same** timestamp on every device — a synced high-water mark clears them consistently. Identity-per-status tracking would be a much larger change for a marginal edge case (a device that *first* observes a status only after another already marked it seen, which only happens when the ship omits `mod-at`).

## Testing
- New `SettingsSyncApplyBucketTest` cases: `applyBucket` publishes the marker to the flow; the marker is **monotonic** (a stale value never regresses it); and a `put-entry` envelope (stringified cord value) updates it.
- Full `desktopTest` suite passes; common + desktop + Android all compile.
- Smoke-tested the packaged **AppImage**: launches, `SettingsSync bootstrap done` across all buckets, home list + rail render, no exceptions.

### Not covered
A live two-device round-trip (needs two clients on one ship). The poke/apply shape is identical to the existing synced buckets, which work in production; I deliberately avoided driving pokes at the real ship for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
