### PR TITLE
Stop auto-marking DMs read when the app isn't focused

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/nisfeb/talon/ui/TalonApp.kt
+++ b/composeApp/src/androidMain/kotlin/io/nisfeb/talon/ui/TalonApp.kt
@@ -571,8 +571,17 @@ fun TalonApp(
     DisposableEffect(Unit) {
         val lifecycle = ProcessLifecycleOwner.get().lifecycle
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
-                app.repo.forceReconnect()
+            when (event) {
+                Lifecycle.Event.ON_START -> {
+                    // Foreground: a chat left open now counts as actively
+                    // viewed again (gates auto-mark-read in the repo).
+                    app.repo.setForeground(true)
+                    app.repo.forceReconnect()
+                }
+                // Background: stop treating the open chat as read so DMs
+                // arriving while away still badge + notify.
+                Lifecycle.Event.ON_STOP -> app.repo.setForeground(false)
+                else -> {}
             }
         }
         lifecycle.addObserver(observer)

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -590,11 +592,23 @@ fun App(
                 }
             }
 
+            // Desktop "is the user actually here" signal = window focus.
+            // Drives the repo's auto-mark-read gate so a chat left open in
+            // an unfocused / minimized window doesn't silently read its
+            // incoming messages, and feeds the notification suppression
+            // below. Without this, a DM open in a background window got
+            // neither an unread badge nor a notification.
+            val windowInfo = LocalWindowInfo.current
+            LaunchedEffect(repo, windowInfo) {
+                snapshotFlow { windowInfo.isWindowFocused }
+                    .collect { focused -> repo.setForeground(focused) }
+            }
+
             // OS notifications for incoming messages. Watches the
             // per-conversation latest-message flow and fires a balloon
             // when a whom's latest id changes to something authored by
-            // someone other than us, AND the chat isn't currently open,
-            // AND the chat isn't muted. Decision logic lives in
+            // someone other than us, AND the chat isn't currently open
+            // *and focused*, AND the chat isn't muted. Decision logic lives in
             // [diffNewMessageNotifications] — kept pure and unit-tested
             // so the seeding behavior can't silently regress.
             //
@@ -627,7 +641,10 @@ fun App(
                                 rows = rows,
                                 lastSeen = lastSeenIds,
                                 ourPatp = loggedInShip,
-                                openChat = openChat,
+                                // Only suppress for the open chat while the
+                                // window is focused — an unfocused window's
+                                // open chat should still notify.
+                                openChat = openChat.takeIf { windowInfo.isWindowFocused },
                                 mutedWhoms = muted,
                                 storyText = { id, json ->
                                     io.nisfeb.talon.urbit.StoryCache.textFor(id, json)

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
@@ -180,6 +180,24 @@ class TlonChatRepo(
      */
     @Volatile private var openWhom: String? = null
 
+    /**
+     * Whether the app is actually in front of the user — foregrounded on
+     * Android, window-focused on desktop. A chat left open in a
+     * backgrounded app or an unfocused/minimized window is NOT being
+     * read, so incoming messages there must still raise the unread badge
+     * and fire a notification. Driven by UI lifecycle via [setForeground].
+     */
+    @Volatile private var appForegrounded: Boolean = true
+
+    /**
+     * The chat the user is *actively viewing right now*: the open chat,
+     * but only while the app is foregrounded. This is the gate for
+     * auto-marking incoming messages read — see [applyActivityUpdate].
+     * Reading [openWhom] alone (the old behaviour) silently marked DMs
+     * read whenever the app was backgrounded with that chat still open.
+     */
+    private fun focusedWhom(): String? = if (appForegrounded) openWhom else null
+
     fun setOpenChat(whom: String?) {
         val prev = openWhom
         openWhom = whom
@@ -190,6 +208,20 @@ class TlonChatRepo(
         }
         if (whom != null && prev != whom) {
             scope.launch { runCatching { markRead(whom) } }
+        }
+    }
+
+    /**
+     * UI lifecycle hook: the app moved to / from the foreground (Android
+     * ON_START/ON_STOP) or the desktop window gained / lost focus. On
+     * regaining focus with a chat still open, the user is looking at it
+     * again, so mark anything that arrived while away as read.
+     */
+    fun setForeground(foreground: Boolean) {
+        val was = appForegrounded
+        appForegrounded = foreground
+        if (foreground && !was) {
+            openWhom?.let { whom -> scope.launch { runCatching { markRead(whom) } } }
         }
     }
 
@@ -2709,7 +2741,7 @@ class TlonChatRepo(
             )
             return
         }
-        val focused = openWhom
+        val focused = focusedWhom()
         val rows = obj.entries.mapNotNull { (sourceKey, summary) ->
             toUnread(sourceKey, summary as? JsonObject ?: return@mapNotNull null)
         }.map { row ->
@@ -2743,8 +2775,8 @@ class TlonChatRepo(
         if (threadRows.isNotEmpty()) db.threadUnreads().upsertAll(threadRows)
     }
 
-    private suspend fun applyActivityUpdate(obj: JsonObject) {
-        val focused = openWhom
+    internal suspend fun applyActivityUpdate(obj: JsonObject) {
+        val focused = focusedWhom()
         (obj["activity"] as? JsonObject)?.let { map ->
             val rows = map.entries.mapNotNull { (key, summary) ->
                 toUnread(key, summary as? JsonObject ?: return@mapNotNull null)

--- a/composeApp/src/desktopTest/kotlin/io/nisfeb/talon/urbit/ActivityFocusReadTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/nisfeb/talon/urbit/ActivityFocusReadTest.kt
@@ -1,0 +1,100 @@
+package io.nisfeb.talon.urbit
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import io.nisfeb.talon.data.AppDatabase
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression guard for "DMs silently marked read": an incoming %activity
+ * update for the open chat was auto-zeroed (no unread badge) and pushed
+ * a markRead to the ship — but only [openWhom] was checked, so a chat
+ * left open while the app was backgrounded (Android) or its window
+ * unfocused (desktop) kept auto-reading. The fix gates the focus
+ * override on [TlonChatRepo.setForeground]; this pins it.
+ */
+class ActivityFocusReadTest {
+
+    private lateinit var tmpDir: File
+    private lateinit var db: AppDatabase
+    private lateinit var repo: TlonChatRepo
+
+    @BeforeTest
+    fun setUp() {
+        tmpDir = createTempDirectory(prefix = "talon-activity-focus-test-").toFile()
+        db = Room.databaseBuilder<AppDatabase>(name = File(tmpDir, "test.db").absolutePath)
+            .setDriver(BundledSQLiteDriver())
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        repo = TlonChatRepo(db = db)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { repo.stop() }
+        runCatching { db.close() }
+        tmpDir.deleteRecursively()
+    }
+
+    /** %activity "activity" envelope: one DM (`~sampel`) with 7 unread. */
+    private fun unreadActivity(whom: String = "~sampel", count: Int = 7): JsonObject =
+        buildJsonObject {
+            put("activity", buildJsonObject {
+                put("ship/$whom", buildJsonObject {
+                    put("count", count)
+                    put("notify-count", count)
+                    put("recency", 1_777_000_000_000L)
+                    put("notify", true)
+                })
+            })
+        }
+
+    @Test
+    fun `open chat while foregrounded is treated as read`() = runBlocking {
+        repo.setOpenChat("~sampel")
+        repo.setForeground(true)
+        repo.applyActivityUpdate(unreadActivity())
+        // Actively viewing it → badge cleared.
+        assertEquals(0, db.unreads().getOne("~sampel")?.count ?: 0)
+    }
+
+    @Test
+    fun `open chat while backgrounded keeps its unread badge`() = runBlocking {
+        // The bug: this used to zero the badge because only openWhom was
+        // checked. Backgrounded → not actually being read → badge stays.
+        repo.setOpenChat("~sampel")
+        repo.setForeground(false)
+        repo.applyActivityUpdate(unreadActivity())
+        assertEquals(7, db.unreads().getOne("~sampel")?.count)
+    }
+
+    @Test
+    fun `returning to foreground resumes treating the open chat as read`() = runBlocking {
+        repo.setOpenChat("~sampel")
+        repo.setForeground(false)
+        repo.applyActivityUpdate(unreadActivity())
+        assertEquals(7, db.unreads().getOne("~sampel")?.count)
+
+        repo.setForeground(true)
+        repo.applyActivityUpdate(unreadActivity())
+        assertEquals(0, db.unreads().getOne("~sampel")?.count)
+    }
+
+    @Test
+    fun `a chat that isn't the open one always keeps its unread`() = runBlocking {
+        repo.setOpenChat("~other")
+        repo.setForeground(true)
+        repo.applyActivityUpdate(unreadActivity(whom = "~sampel"))
+        // Not the focused chat → never zeroed, foreground or not.
+        assertEquals(7, db.unreads().getOne("~sampel")?.count)
+    }
+}


### PR DESCRIPTION
## Symptom
DMs were getting silently marked read — **no notification and no unread badge** — so messages (often from the user's wife) went unnoticed until much later.

## Root cause
"Actively viewing a chat" was derived from `openWhom`/`openChat` **alone**, with no check for whether the app is actually in front of the user. And `openWhom` is only cleared when `DmChatScreen` *unmounts* (navigating away) — **not** when the app is backgrounded or the window loses focus. So a chat left open while you switch away stays "focused" indefinitely.

When a new message then arrived, `applyActivityUpdate` (`TlonChatRepo`) matched `openWhom` and:
1. **zeroed the local unread** → no badge, and
2. **poked `markRead` to the ship** → which propagates "read" to *all* the user's devices (intentional, to keep Tlon webapp/mobile in sync) and stops re-notification.

The desktop case reproduces both symptoms exactly: the DM open in an unfocused/minimized window → the message is auto-read (no badge), and the desktop notification path suppressed it on `openChat` with no focus check (no notification) → and that "read" then cleared the badge on the phone too.

## Fix
A chat counts as focused only when it's **open AND the app is in front of the user**.

- **`TlonChatRepo`**: add an `appForegrounded` flag + `setForeground()`, and a `focusedWhom()` (= `openWhom` only while foregrounded) that gates *both* activity read-overrides (`applyActivityUpdate`, `bootstrapActivity`). Returning to the foreground with a chat still open marks it read again.
- **Android** (`TalonApp.kt`): the existing `ProcessLifecycle` observer now calls `setForeground(true)` on `ON_START`, `false` on `ON_STOP`.
- **Desktop** (`App.kt`): `setForeground` is driven by `LocalWindowInfo.isWindowFocused`, and notification suppression only applies to the open chat **while the window is focused**.

## Testing
New `ActivityFocusReadTest` drives `applyActivityUpdate` against a real Room DB:
- foregrounded + open ⇒ read (badge cleared)
- **backgrounded + open ⇒ badge stays** (the regression)
- foreground-return ⇒ read again
- a non-open chat ⇒ never zeroed

Full `desktopTest` suite passes; common + desktop + Android all compile.

### Needs on-device verification
The repo gate is unit-tested, but the platform signals (Android `ProcessLifecycle`, desktop window focus) aren't reachable from `desktopTest`. Verify live: open a DM, background the app / unfocus the window, have someone message you → you should now get an unread badge **and** a notification, and the DM should stay unread until you actually look at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
