### PR TITLE
Stop rendering two link previews for a server-enriched URL

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/LinkPreviewCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/LinkPreviewCard.kt
@@ -98,18 +98,33 @@ fun LinkPreviewCard(
 }
 
 /**
- * Scan a list of StoryParts for the first URL annotation. Returns null
- * if none found — skips the preview card entirely in that case.
+ * The first URL in [parts] that the story doesn't already preview
+ * itself — the one the client-side [LinkPreviewCard] should render.
+ *
+ * Tlon's server enriches some links into a `block.link`
+ * ([io.nisfeb.talon.urbit.StoryPart.LinkPreview]) that the story
+ * renderer already shows inline. The client card must skip those, or a
+ * server-previewed URL renders TWO previews — the story's plus the
+ * card below it. URLs with no server preview still get a card. Returns
+ * null when there's nothing left to preview.
  */
 fun firstLinkUrl(parts: List<io.nisfeb.talon.urbit.StoryPart>): String? {
+    // URLs the story already previews. Trailing slash normalized so the
+    // server's echoed url and the typed url match (`example.com/` vs
+    // `example.com`).
+    val previewed = parts.asSequence()
+        .filterIsInstance<io.nisfeb.talon.urbit.StoryPart.LinkPreview>()
+        .mapTo(HashSet()) { it.url.trimEnd('/') }
     for (p in parts) {
         if (p is io.nisfeb.talon.urbit.StoryPart.Text) {
-            val ann = p.text.getStringAnnotations(
+            val anns = p.text.getStringAnnotations(
                 tag = io.nisfeb.talon.urbit.URL_TAG,
                 start = 0,
                 end = p.text.length,
-            ).firstOrNull()
-            if (ann != null) return ann.item
+            )
+            for (ann in anns) {
+                if (ann.item.trimEnd('/') !in previewed) return ann.item
+            }
         }
     }
     return null

--- a/composeApp/src/commonTest/kotlin/io/nisfeb/talon/ui/FirstLinkUrlTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/nisfeb/talon/ui/FirstLinkUrlTest.kt
@@ -1,0 +1,75 @@
+package io.nisfeb.talon.ui
+
+import androidx.compose.ui.text.buildAnnotatedString
+import io.nisfeb.talon.urbit.StoryPart
+import io.nisfeb.talon.urbit.URL_TAG
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins [firstLinkUrl]'s dedup: the client-side LinkPreviewCard must not
+ * re-preview a URL the story already shows via a server `block.link`
+ * ([StoryPart.LinkPreview]) — otherwise a single URL renders two cards
+ * (one above from the story, one below from the client). The reported bug.
+ */
+class FirstLinkUrlTest {
+
+    /** A Text part with [url] linkified (URL_TAG annotation), as the
+     *  story renderer produces for a bare/markdown link. */
+    private fun textWithUrl(prefix: String, url: String): StoryPart.Text =
+        StoryPart.Text(
+            buildAnnotatedString {
+                append(prefix)
+                pushStringAnnotation(URL_TAG, url)
+                append(url)
+                pop()
+            },
+        )
+
+    private fun preview(url: String): StoryPart.LinkPreview =
+        StoryPart.LinkPreview(url = url, title = null, description = null, imageUrl = null, siteName = null)
+
+    @Test
+    fun `a URL with no server preview gets a client card`() {
+        val parts = listOf(textWithUrl("see ", "https://example.com/post"))
+        assertEquals("https://example.com/post", firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `a URL the story already previews is skipped`() {
+        // The bug: text URL + matching server block.link → only the
+        // story's preview should show, so the client card is suppressed.
+        val parts = listOf(
+            preview("https://example.com/post"),
+            textWithUrl("see ", "https://example.com/post"),
+        )
+        assertNull(firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `trailing-slash difference still counts as already previewed`() {
+        val parts = listOf(
+            preview("https://example.com/post/"),
+            textWithUrl("see ", "https://example.com/post"),
+        )
+        assertNull(firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `a second un-previewed URL still gets a card`() {
+        // First URL is server-previewed; the distinct second URL isn't,
+        // so it should still surface a client card.
+        val parts = listOf(
+            preview("https://example.com/a"),
+            textWithUrl("first ", "https://example.com/a"),
+            textWithUrl("second ", "https://other.com/b"),
+        )
+        assertEquals("https://other.com/b", firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `no links yields null`() {
+        assertNull(firstLinkUrl(listOf(StoryPart.Text(buildAnnotatedString { append("plain text") }))))
+    }
+}


### PR DESCRIPTION
## Symptom
Sometimes a posted URL renders **two** link previews — one above and one below the URL.

## Root cause
A message URL can be previewed by two independent sources, both rendered in the `DmChatScreen` message row:
1. **Server-side** — Tlon enriches some links into a `block.link`, parsed to `StoryPart.LinkPreview` and drawn inline by `StoryRenderer` (appears **above**, at the block's position).
2. **Client-side** — right after the story, the row calls `firstLinkUrl(parts)` and renders its own `LinkPreviewCard` (appears **below**).

`firstLinkUrl` returned the first URL annotation in the text **without checking whether the story already previews it**, so a server-enriched URL produced both. It's intermittent because the duplicate only appears when the server actually supplied a `block.link` for that URL.

## Fix
`firstLinkUrl` now skips any URL already covered by a `StoryPart.LinkPreview` — it collects the server-previewed URLs (trailing-slash normalized so `example.com/` matches `example.com`) and returns the first text URL *not* among them.

- URL with a server preview → no client card (the richer server preview wins). **Duplicate gone.**
- URL with no server preview → still gets a client card. **Preserved.**
- A distinct second un-previewed URL still surfaces its own card.

One shared function, one call site (`DmChatScreen`) — threads/notebooks never rendered the client card, and `MediaListPane`'s preview is a separate surface; both unaffected.

## Testing
New `FirstLinkUrlTest` (commonTest) pins all five cases: no-server-preview shows a card, server-previewed URL suppressed, trailing-slash match, second-URL still cards, empty → null. Full `desktopTest` suite passes; compiles on common/desktop/Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
