### PR TITLE
Surface pending DM requests (notify + accept/decline)

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/nisfeb/talon/data/AppDatabase.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/nisfeb/talon/data/AppDatabase.android.kt
@@ -31,6 +31,7 @@ actual abstract class AppDatabase : RoomDatabase() {
     actual abstract fun dailyDigests(): DailyDigestDao
     actual abstract fun messageMedia(): MessageMediaDao
     actual abstract fun railItemPrefs(): RailItemPrefDao
+    actual abstract fun dmInvites(): DmInviteDao
 }
 
 /**

--- a/composeApp/src/androidMain/kotlin/io/nisfeb/talon/ui/TalonApp.kt
+++ b/composeApp/src/androidMain/kotlin/io/nisfeb/talon/ui/TalonApp.kt
@@ -553,7 +553,26 @@ fun TalonApp(
                 }
             }
         }
-        onDispose { app.repo.messageListener = null }
+        // New pending DM request → notify. Always fires (there's no
+        // "open" state for an unaccepted request), so a brand-new DM no
+        // longer arrives silently.
+        app.repo.dmInviteListener = { ship ->
+            appScope.launch {
+                Notifications.showMessage(
+                    context = context,
+                    whom = ship,
+                    postId = ship,
+                    parentId = null,
+                    title = contactMap.displayName(ship),
+                    body = "wants to message you",
+                    sentMs = System.currentTimeMillis(),
+                )
+            }
+        }
+        onDispose {
+            app.repo.messageListener = null
+            app.repo.dmInviteListener = null
+        }
     }
 
     // Foreground catch-up: when the app returns to the front, force a

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/compose/App.kt
@@ -604,6 +604,16 @@ fun App(
                     .collect { focused -> repo.setForeground(focused) }
             }
 
+            // New pending DM request → tray notification. Always fires
+            // (an unaccepted request has no "open" state to suppress
+            // against), so a brand-new DM no longer arrives silently.
+            DisposableEffect(repo, notifier) {
+                repo.dmInviteListener = { ship ->
+                    runCatching { notifier.notify(ship, "wants to message you") }
+                }
+                onDispose { repo.dmInviteListener = null }
+            }
+
             // OS notifications for incoming messages. Watches the
             // per-conversation latest-message flow and fires a balloon
             // when a whom's latest id changes to something authored by

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/data/AppDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/data/AppDatabase.kt
@@ -49,8 +49,9 @@ import androidx.room.RoomDatabaseConstructor
         DailyDigestEntity::class,
         MessageMediaEntity::class,
         RailItemPrefEntity::class,
+        DmInviteEntity::class,
     ],
-    version = 33,
+    version = 34,
     exportSchema = false,
 )
 @ConstructedBy(AppDatabaseConstructor::class)
@@ -73,6 +74,7 @@ expect abstract class AppDatabase : RoomDatabase {
     abstract fun dailyDigests(): DailyDigestDao
     abstract fun messageMedia(): MessageMediaDao
     abstract fun railItemPrefs(): RailItemPrefDao
+    abstract fun dmInvites(): DmInviteDao
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/data/DmInviteDao.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/data/DmInviteDao.kt
@@ -1,0 +1,25 @@
+package io.nisfeb.talon.data
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface DmInviteDao {
+    @Upsert
+    suspend fun upsertAll(entities: List<DmInviteEntity>)
+
+    @Query("DELETE FROM dm_invites WHERE ship = :ship")
+    suspend fun delete(ship: String)
+
+    @Query("DELETE FROM dm_invites")
+    suspend fun clear()
+
+    @Query("SELECT * FROM dm_invites ORDER BY receivedMs DESC")
+    fun stream(): Flow<List<DmInviteEntity>>
+
+    /** Ships currently pending — used to diff a fresh invite snapshot. */
+    @Query("SELECT ship FROM dm_invites")
+    suspend fun allShips(): List<String>
+}

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/data/DmInviteEntity.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/data/DmInviteEntity.kt
@@ -1,0 +1,25 @@
+package io.nisfeb.talon.data
+
+import androidx.compose.runtime.Immutable
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A pending DM request — a ship that opened a DM with us that we haven't
+ * accepted or declined yet. In Tlon, a DM from a non-contact lands as an
+ * "invite" rather than a conversation: its writs don't flow over the
+ * normal subscription until accepted, so without this Talon never
+ * surfaced it (no list row, no notification).
+ *
+ * Sourced from %chat's `/dm/invited` scry at bootstrap + the live
+ * ship-array facts the chat `/v4` subscription pushes. Accept/decline
+ * via the `chat-dm-rsvp` poke; the row is then removed (accept turns it
+ * into a real DM whose messages flow normally).
+ */
+@Immutable
+@Entity(tableName = "dm_invites")
+data class DmInviteEntity(
+    @PrimaryKey val ship: String,
+    /** Local ms when we first observed this invite — drives ordering. */
+    val receivedMs: Long,
+)

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/LinkPreviewCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/LinkPreviewCard.kt
@@ -98,18 +98,33 @@ fun LinkPreviewCard(
 }
 
 /**
- * Scan a list of StoryParts for the first URL annotation. Returns null
- * if none found — skips the preview card entirely in that case.
+ * The first URL in [parts] that the story doesn't already preview
+ * itself — the one the client-side [LinkPreviewCard] should render.
+ *
+ * Tlon's server enriches some links into a `block.link`
+ * ([io.nisfeb.talon.urbit.StoryPart.LinkPreview]) that the story
+ * renderer already shows inline. The client card must skip those, or a
+ * server-previewed URL renders TWO previews — the story's plus the
+ * card below it. URLs with no server preview still get a card. Returns
+ * null when there's nothing left to preview.
  */
 fun firstLinkUrl(parts: List<io.nisfeb.talon.urbit.StoryPart>): String? {
+    // URLs the story already previews. Trailing slash normalized so the
+    // server's echoed url and the typed url match (`example.com/` vs
+    // `example.com`).
+    val previewed = parts.asSequence()
+        .filterIsInstance<io.nisfeb.talon.urbit.StoryPart.LinkPreview>()
+        .mapTo(HashSet()) { it.url.trimEnd('/') }
     for (p in parts) {
         if (p is io.nisfeb.talon.urbit.StoryPart.Text) {
-            val ann = p.text.getStringAnnotations(
+            val anns = p.text.getStringAnnotations(
                 tag = io.nisfeb.talon.urbit.URL_TAG,
                 start = 0,
                 end = p.text.length,
-            ).firstOrNull()
-            if (ann != null) return ann.item
+            )
+            for (ann in anns) {
+                if (ann.item.trimEnd('/') !in previewed) return ann.item
+            }
         }
     }
     return null

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/ui/screens/DmListScreen.kt
@@ -212,6 +212,10 @@ fun DmListScreen(
     // the per-write work. distinctUntilChanged on each Room source
     // suppresses Room's spurious re-emissions on unrelated table
     // writes; the row-build runs on Default so it never lands on Main.
+    // Pending DM requests — strangers who opened a DM we haven't accepted.
+    // Rendered as a "Requests" section at the top of the list.
+    val dmInvites by remember { db.dmInvites().stream() }
+        .collectAsState(initial = emptyList())
     val rows by remember {
         combine(
             db.messages().conversationLatest().distinctUntilChanged(),
@@ -959,6 +963,41 @@ fun DmListScreen(
             contentPadding = PaddingValues(vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(0.dp),
         ) {
+            // Pending DM requests pinned to the top — Accept opens the
+            // conversation, Decline dismisses it. Always shown (any tab)
+            // so a new DM can't hide behind a folder/special selection.
+            if (dmInvites.isNotEmpty()) {
+                item(key = "__dm_requests_header", contentType = "req_header") {
+                    Text(
+                        "Requests",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
+                items(
+                    items = dmInvites,
+                    key = { "req:${it.ship}" },
+                    contentType = { "req" },
+                ) { invite ->
+                    DmRequestRow(
+                        ship = invite.ship,
+                        contactMap = contactMap,
+                        onAccept = {
+                            repo.pushScope.launch {
+                                runCatching { repo.acceptDmInvite(invite.ship) }
+                            }
+                            currentOnOpenConversation(invite.ship)
+                        },
+                        onDecline = {
+                            repo.pushScope.launch {
+                                runCatching { repo.declineDmInvite(invite.ship) }
+                            }
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
             if (selectedFolderId == null && selectedSpecial == SpecialTab.Unread) {
                 // Unread view — flat list of whoms with pending pings.
                 // Read-only (no drag-reorder, no section headers).
@@ -1748,6 +1787,42 @@ private fun FolderCreateDialog(onCreate: (String) -> Unit, onDismiss: () -> Unit
 }
 
 @OptIn(ExperimentalFoundationApi::class)
+/** A pending DM request row: avatar + name, with Decline / Accept. */
+@Composable
+private fun DmRequestRow(
+    ship: String,
+    contactMap: ContactMap,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+) {
+    val label = remember(ship, contactMap) { contactMap.nickname(ship) ?: ship }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Avatar(
+            label = label,
+            url = contactMap.conversationAvatar(ship),
+        )
+        Column(Modifier.weight(1f)) {
+            Text(label, style = MaterialTheme.typography.bodyLarge, maxLines = 1)
+            Text(
+                "wants to message you",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+        TextButton(onClick = onDecline) {
+            Text("Decline", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        TextButton(onClick = onAccept) { Text("Accept") }
+    }
+}
+
 @Composable
 private fun ConversationRow(
     m: MessageEntity,

--- a/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
+++ b/composeApp/src/commonMain/kotlin/io/nisfeb/talon/urbit/TlonChatRepo.kt
@@ -29,6 +29,7 @@ import io.nisfeb.talon.data.AppDatabase
 import io.nisfeb.talon.data.ChannelGroupEntity
 import io.nisfeb.talon.data.ClubEntity
 import io.nisfeb.talon.data.ContactEntity
+import io.nisfeb.talon.data.DmInviteEntity
 import io.nisfeb.talon.data.GroupEntity
 import io.nisfeb.talon.data.MessageEntity
 import io.nisfeb.talon.data.ReactionEntity
@@ -241,6 +242,14 @@ class TlonChatRepo(
      */
     @Volatile var messageListener: ((MessageEntity, Boolean) -> Unit)? = null
 
+    /**
+     * Called once per newly-arrived pending DM request (a ship that just
+     * opened a DM with us, live — not on bootstrap). UI wires this to the
+     * notification path, same as [messageListener]. The ship is the
+     * inviter's patp.
+     */
+    @Volatile var dmInviteListener: ((ship: String) -> Unit)? = null
+
     fun start(session: UrbitSession) {
         if (started) return
         started = true
@@ -419,6 +428,10 @@ class TlonChatRepo(
                 runCatching { bootstrapChannelOrders(ch) }
                     .onFailure { Log.e(TAG, "channel orders scry failed", it) }
             }
+            val dmInvitesJob = async {
+                runCatching { bootstrapDmInvites(ch) }
+                    .onFailure { Log.e(TAG, "dm-invites scry failed", it) }
+            }
             val firstRunJobs = if (firstRun) {
                 listOf(
                     async {
@@ -431,7 +444,7 @@ class TlonChatRepo(
                     },
                 )
             } else emptyList()
-            (listOf(initJob, activityJob, contactsJob, ordersJob) + firstRunJobs).awaitAll()
+            (listOf(initJob, activityJob, contactsJob, ordersJob, dmInvitesJob) + firstRunJobs).awaitAll()
         } finally {
             if (firstRun) _bootstrapping.value = false
         }
@@ -2421,6 +2434,12 @@ class TlonChatRepo(
             return
         }
         if (response != "diff") return
+        // %chat pushes the full pending-DM-invite ship list as a bare
+        // JSON array on the chat /v4 subscription (the other agents only
+        // ever emit objects, so an array is unambiguously this). Handle
+        // it before the object cast below drops it on the floor — that
+        // drop is why brand-new DMs were invisible.
+        (outer["json"] as? JsonArray)?.let { applyDmInvites(it, notify = true); return }
         val payload = outer["json"] as? JsonObject ?: return
 
         // %chat writ-response-4: { whom, id, response }
@@ -2827,6 +2846,67 @@ class TlonChatRepo(
             sourceToWhom(source)?.let { db.unreads().delete(it) }
             return
         }
+    }
+
+    // ───────── pending DM requests ─────────
+
+    /**
+     * Scry the full pending-DM-invite list at (re)connect. `%chat`
+     * `/dm/invited` returns a JSON array of inviter patps. Bootstrap
+     * doesn't notify — a launch shouldn't fire a balloon for every
+     * already-pending request; only live arrivals (via [applyEvent]) do.
+     */
+    private suspend fun bootstrapDmInvites(channel: UrbitChannel) {
+        val body = runCatching { channel.scry("chat", "/dm/invited") }
+            .onFailure { Log.w(TAG, "dm/invited scry failed", it) }
+            .getOrNull() as? JsonArray ?: return
+        applyDmInvites(body, notify = false)
+    }
+
+    /**
+     * Reconcile the local pending-invite table against a fresh snapshot
+     * (the complete list `%chat` sends each time). Ships new to us are
+     * inserted (and, when [notify] is true, surfaced to
+     * [dmInviteListener]); ships no longer present — accepted/declined
+     * elsewhere — are removed.
+     */
+    internal suspend fun applyDmInvites(arr: JsonArray, notify: Boolean) {
+        val incoming = arr.mapNotNull { (it as? JsonPrimitive)?.takeIf { p -> p.isString }?.content }
+            .filter { it.startsWith("~") }
+            .toSet()
+        val existing = db.dmInvites().allShips().toSet()
+        val added = incoming - existing
+        val removed = existing - incoming
+        if (added.isNotEmpty()) {
+            val now = System.currentTimeMillis()
+            db.dmInvites().upsertAll(added.map { DmInviteEntity(ship = it, receivedMs = now) })
+        }
+        removed.forEach { db.dmInvites().delete(it) }
+        if (notify) added.forEach { ship -> runCatching { dmInviteListener?.invoke(ship) } }
+    }
+
+    /**
+     * Accept a pending DM request: poke `chat-dm-rsvp` with `ok=true`.
+     * The DM becomes a real conversation whose writs then flow normally;
+     * drop the local invite row immediately (the next `/v4` snapshot also
+     * reflects it).
+     */
+    suspend fun acceptDmInvite(ship: String) = rsvpDmInvite(ship, accept = true)
+
+    /** Decline a pending DM request: poke `chat-dm-rsvp` with `ok=false`. */
+    suspend fun declineDmInvite(ship: String) = rsvpDmInvite(ship, accept = false)
+
+    private suspend fun rsvpDmInvite(ship: String, accept: Boolean) {
+        val ch = channel ?: error("not connected")
+        ch.poke(
+            app = "chat",
+            mark = "chat-dm-rsvp",
+            payload = buildJsonObject {
+                put("ship", ship)
+                put("ok", accept)
+            },
+        )
+        db.dmInvites().delete(ship)
     }
 
     /**

--- a/composeApp/src/commonTest/kotlin/io/nisfeb/talon/ui/FirstLinkUrlTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/nisfeb/talon/ui/FirstLinkUrlTest.kt
@@ -1,0 +1,75 @@
+package io.nisfeb.talon.ui
+
+import androidx.compose.ui.text.buildAnnotatedString
+import io.nisfeb.talon.urbit.StoryPart
+import io.nisfeb.talon.urbit.URL_TAG
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins [firstLinkUrl]'s dedup: the client-side LinkPreviewCard must not
+ * re-preview a URL the story already shows via a server `block.link`
+ * ([StoryPart.LinkPreview]) — otherwise a single URL renders two cards
+ * (one above from the story, one below from the client). The reported bug.
+ */
+class FirstLinkUrlTest {
+
+    /** A Text part with [url] linkified (URL_TAG annotation), as the
+     *  story renderer produces for a bare/markdown link. */
+    private fun textWithUrl(prefix: String, url: String): StoryPart.Text =
+        StoryPart.Text(
+            buildAnnotatedString {
+                append(prefix)
+                pushStringAnnotation(URL_TAG, url)
+                append(url)
+                pop()
+            },
+        )
+
+    private fun preview(url: String): StoryPart.LinkPreview =
+        StoryPart.LinkPreview(url = url, title = null, description = null, imageUrl = null, siteName = null)
+
+    @Test
+    fun `a URL with no server preview gets a client card`() {
+        val parts = listOf(textWithUrl("see ", "https://example.com/post"))
+        assertEquals("https://example.com/post", firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `a URL the story already previews is skipped`() {
+        // The bug: text URL + matching server block.link → only the
+        // story's preview should show, so the client card is suppressed.
+        val parts = listOf(
+            preview("https://example.com/post"),
+            textWithUrl("see ", "https://example.com/post"),
+        )
+        assertNull(firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `trailing-slash difference still counts as already previewed`() {
+        val parts = listOf(
+            preview("https://example.com/post/"),
+            textWithUrl("see ", "https://example.com/post"),
+        )
+        assertNull(firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `a second un-previewed URL still gets a card`() {
+        // First URL is server-previewed; the distinct second URL isn't,
+        // so it should still surface a client card.
+        val parts = listOf(
+            preview("https://example.com/a"),
+            textWithUrl("first ", "https://example.com/a"),
+            textWithUrl("second ", "https://other.com/b"),
+        )
+        assertEquals("https://other.com/b", firstLinkUrl(parts))
+    }
+
+    @Test
+    fun `no links yields null`() {
+        assertNull(firstLinkUrl(listOf(StoryPart.Text(buildAnnotatedString { append("plain text") }))))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/io/nisfeb/talon/data/AppDatabase.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/io/nisfeb/talon/data/AppDatabase.desktop.kt
@@ -43,6 +43,7 @@ actual abstract class AppDatabase : RoomDatabase() {
     actual abstract fun dailyDigests(): DailyDigestDao
     actual abstract fun messageMedia(): MessageMediaDao
     actual abstract fun railItemPrefs(): RailItemPrefDao
+    actual abstract fun dmInvites(): DmInviteDao
 }
 
 /**

--- a/composeApp/src/desktopTest/kotlin/io/nisfeb/talon/urbit/DmInviteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/nisfeb/talon/urbit/DmInviteTest.kt
@@ -1,0 +1,98 @@
+package io.nisfeb.talon.urbit
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import io.nisfeb.talon.data.AppDatabase
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins pending-DM-request reconciliation: %chat sends the complete
+ * invited-ship list (bootstrap scry + live `/v4` array facts), and
+ * [TlonChatRepo.applyDmInvites] diffs it into the local table — adding
+ * new requests (notifying only on live arrivals), and dropping ones
+ * accepted/declined elsewhere. This is what makes a brand-new DM visible.
+ */
+class DmInviteTest {
+
+    private lateinit var tmpDir: File
+    private lateinit var db: AppDatabase
+    private lateinit var repo: TlonChatRepo
+
+    @BeforeTest
+    fun setUp() {
+        tmpDir = createTempDirectory(prefix = "talon-dm-invite-test-").toFile()
+        db = Room.databaseBuilder<AppDatabase>(name = File(tmpDir, "test.db").absolutePath)
+            .setDriver(BundledSQLiteDriver())
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        repo = TlonChatRepo(db = db)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { repo.stop() }
+        runCatching { db.close() }
+        tmpDir.deleteRecursively()
+    }
+
+    private fun ships(vararg s: String): JsonArray =
+        buildJsonArray { s.forEach { add(JsonPrimitive(it)) } }
+
+    @Test
+    fun `live invites are stored and notified`() = runBlocking {
+        val notified = mutableListOf<String>()
+        repo.dmInviteListener = { notified += it }
+        repo.applyDmInvites(ships("~sampel-palnet", "~bus"), notify = true)
+        assertEquals(setOf("~sampel-palnet", "~bus"), db.dmInvites().allShips().toSet())
+        assertEquals(setOf("~sampel-palnet", "~bus"), notified.toSet())
+    }
+
+    @Test
+    fun `bootstrap stores invites without notifying`() = runBlocking {
+        val notified = mutableListOf<String>()
+        repo.dmInviteListener = { notified += it }
+        repo.applyDmInvites(ships("~sampel"), notify = false)
+        assertEquals(listOf("~sampel"), db.dmInvites().allShips())
+        assertTrue(notified.isEmpty(), "bootstrap must not fire notifications")
+    }
+
+    @Test
+    fun `a fresh snapshot drops invites no longer present`() = runBlocking {
+        repo.applyDmInvites(ships("~a-a", "~b-b"), notify = false)
+        // ~a-a accepted/declined elsewhere → gone from the next snapshot.
+        repo.applyDmInvites(ships("~b-b"), notify = false)
+        assertEquals(listOf("~b-b"), db.dmInvites().allShips())
+    }
+
+    @Test
+    fun `only newly-added ships notify, not already-pending ones`() = runBlocking {
+        val notified = mutableListOf<String>()
+        repo.dmInviteListener = { notified += it }
+        repo.applyDmInvites(ships("~a-a"), notify = true)
+        repo.applyDmInvites(ships("~a-a", "~c-c"), notify = true)
+        // ~a-a notified once (first arrival), ~c-c once — re-sending the
+        // full list must not re-notify a still-pending request.
+        assertEquals(listOf("~a-a", "~c-c"), notified)
+    }
+
+    @Test
+    fun `non-ship and non-string entries are ignored`() = runBlocking {
+        val arr = buildJsonArray {
+            add(JsonPrimitive("~ok-ok"))
+            add(JsonPrimitive("notaship")) // no ~ prefix
+            add(JsonPrimitive(5))          // not a string
+        }
+        repo.applyDmInvites(arr, notify = false)
+        assertEquals(listOf("~ok-ok"), db.dmInvites().allShips())
+    }
+}


### PR DESCRIPTION
## Problem
A brand-new DM from someone (especially a non-contact) was completely silent — no notification, no DM-list entry, no badge. The user found one by accident.

In Tlon, a DM from a stranger lands as an unaccepted **invite/request**, not a conversation: its writs don't flow over the normal subscription until accepted. Talon only parsed the `dm-invite` for the **Activity feed screen** — that's the one place it surfaced.

## Root cause
`%chat` already pushes the full pending-invite ship list — as a bare **JSON array** on the existing `chat /v4` subscription (plus a `/dm/invited` bootstrap scry). But `applyEvent` dropped array facts at `outer["json"] as? JsonObject ?: return`, so the live signal was arriving and being silently discarded.

## What this adds
- **`dm_invites` Room table** (schema 33→34, destructive-fallback migration like the rest — the DB re-syncs from the ship on first launch) + `DmInviteDao`.
- **`TlonChatRepo`**: `bootstrapDmInvites` (`/dm/invited` scry), an `applyEvent` branch that catches the array fact, `applyDmInvites` reconciling each full snapshot (add new / drop ones resolved elsewhere) and notifying live arrivals via a new `dmInviteListener`, and `acceptDmInvite`/`declineDmInvite` (poke `chat-dm-rsvp` `{ship, ok}`).
- **`DmListScreen`**: a "Requests" section pinned to the top — Accept (poke + open the conversation) / Decline.
- **Android + desktop** wire `dmInviteListener` to a notification, so a new DM no longer arrives silently.

## Protocol
Verified against tlon-apps (`packages/api/src/client/chatApi.ts`, `desk/app/chat.hoon`): scry `/dm/invited` → `string[]` of inviters; poke `chat-dm-rsvp` `{ship, ok}`; and the bare-array invite-sync fact on the chat subscription.

## Testing
`DmInviteTest` drives `applyDmInvites` against a real DB: live invites stored + notified, bootstrap stored without notifying, a fresh snapshot drops resolved invites, only newly-added ships notify (no re-notify of still-pending), and non-ship/non-string entries are ignored. Full `desktopTest` suite passes; common + desktop + Android compile.

### Needs on-device verification
A true end-to-end round-trip (a real stranger DMing you → notification → Requests row → Accept/Decline) can't be reproduced against the dev fakeship. Worth a live check: have someone open a new DM and confirm the notification + Requests row, then Accept/Decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
